### PR TITLE
feat: frontend habits/todo page so  user can create, edit and delete todos and habits from their dashboard. closes #16

### DIFF
--- a/app/app/habits/index.tsx
+++ b/app/app/habits/index.tsx
@@ -1,10 +1,549 @@
-import React from 'react';
+'use client'
+
+import { HabitCard } from '@/components/habit-card'
+import { TodoCard } from '@/components/todo-card'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useAuth } from '@/hooks/useAuth'
+import { useApi } from '@/hooks/useApi'
+import type { Habit, HabitCategory, HabitFrequency, NewHabit, NewTodo, Todo } from '@/types/task'
+import { Plus, Minus, Flame, Brain, Heart } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+
+function weightLabel(w: number) {
+  return w === 1 ? 'Easy' : w === 2 ? 'Medium' : 'Hard'
+}
+
+// ─── main page ────────────────────────────────────────────────────────────────
 
 export default function HabitsPage() {
+  const { user } = useAuth()
+  const [activeTab, setActiveTab] = useState<'habits' | 'todos'>('habits')
+
+  if (!user) return null
+
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold">Habits</h1>
-      <p>This is a placeholder page for Habits.</p>
+    <main className='flex flex-1 flex-col gap-4 p-4 pt-0'>
+      <h1 className='text-3xl font-bold tracking-tight'>Tasks</h1>
+
+      {/* tab switcher */}
+      <div className='flex gap-2'>
+        <button
+          onClick={() => setActiveTab('habits')}
+          className={`rounded-full px-5 py-2 text-sm font-medium transition-colors
+            ${activeTab === 'habits'
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-border bg-muted/40 text-muted-foreground hover:bg-muted'
+            }`}
+        >
+          Habits
+        </button>
+        <button
+          onClick={() => setActiveTab('todos')}
+          className={`rounded-full px-5 py-2 text-sm font-medium transition-colors
+            ${activeTab === 'todos'
+              ? 'bg-primary text-primary-foreground'
+              : 'border border-border bg-muted/40 text-muted-foreground hover:bg-muted'
+            }`}
+        >
+          To-Dos
+        </button>
+      </div>
+
+      {activeTab === 'habits' && <HabitsSection userId={user.id} />}
+      {activeTab === 'todos'  && <TodosSection  userId={user.id} />}
+    </main>
+  )
+}
+
+// ─── habits ───────────────────────────────────────────────────────────
+
+function HabitsSection({ userId }: { userId: string | number }) {
+  const api = useApi()
+  const [habits, setHabits]       = useState<Habit[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError]         = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const [newHabit, setNewHabit] = useState<NewHabit>({
+    title:       '',
+    description: '',
+    category:    'PHYSICAL',
+    frequency:   'DAILY',
+    positive:    true,
+    weight:      1,
+  })
+
+  useEffect(() => { void fetchHabits() }, [userId])
+
+  async function fetchHabits() {
+    try {
+      setIsLoading(true)
+      const data = await api.get<Habit[]>(`/users/${userId}/habits`)
+      setHabits(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load habits')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  async function createHabit() {
+    if (!newHabit.title.trim()) return
+    try {
+      const created = await api.post<Habit>(`/users/${userId}/habits`, newHabit)
+      setHabits(prev => [...prev, created])
+      setNewHabit({ title: '', description: '', category: 'PHYSICAL',
+                    frequency: 'DAILY', positive: true, weight: 1 })
+      setDialogOpen(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create habit')
+    }
+  }
+
+  async function completeHabit(habitId: number) {
+    try {
+      const updated = await api.put<Habit>(
+        `/users/${userId}/habits/${habitId}/complete`, {})
+      setHabits(prev => prev.map(h => h.id === habitId ? updated : h))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to complete habit')
+    }
+  }
+
+  async function deleteHabit(habitId: number) {
+    try {
+      await api.delete(`/users/${userId}/habits/${habitId}`)
+      setHabits(prev => prev.filter(h => h.id !== habitId))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete habit')
+    }
+  }
+
+  if (isLoading) {
+    return <p className='text-muted-foreground'>Loading habits...</p>
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {error && (
+        <div className='rounded-lg bg-red-50 border border-red-200 px-4 py-3'>
+          <p className='text-sm text-red-700'>{error}</p>
+        </div>
+      )}
+
+      {/* create button + dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger asChild>
+          <Button className='w-fit'>
+            <Plus className='mr-2 h-4 w-4' /> Add Habit
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Habit</DialogTitle>
+          </DialogHeader>
+          <HabitForm
+            value={newHabit}
+            onChange={setNewHabit}
+            onSubmit={createHabit}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* list */}
+      {habits.length === 0 ? (
+        <EmptyState message='No habits yet. Add one to start earning XP!' />
+      ) : (
+        <div className='flex flex-col gap-3'>
+          {habits.map(habit => (
+            <HabitCard
+              key={habit.id}
+              habit={habit}
+              onComplete={() => void completeHabit(habit.id)}
+              onDelete={() => void deleteHabit(habit.id)}
+            />
+          ))}
+        </div>
+      )}
     </div>
+  )
+}
+
+// ─── todos ────────────────────────────────────────────────────────────
+
+function TodosSection({ userId }: { userId: string | number }) {
+  const api = useApi()
+  const [todos, setTodos]         = useState<Todo[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError]         = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const [newTodo, setNewTodo] = useState<NewTodo>({
+    title:       '',
+    description: '',
+    category:    'PHYSICAL',
+    weight:      1,
+    dueAt:       '',
+  })
+
+  useEffect(() => { void fetchTodos() }, [userId])
+
+  async function fetchTodos() {
+    try {
+      setIsLoading(true)
+      const data = await api.get<Todo[]>(`/users/${userId}/todos`)
+      setTodos(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load todos')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  async function createTodo() {
+    if (!newTodo.title.trim()) return
+    try {
+      const payload = {
+        ...newTodo,
+        dueAt: newTodo.dueAt
+          ? new Date(newTodo.dueAt).toISOString()
+          : undefined,
+      }
+      const created = await api.post<Todo>(`/users/${userId}/todos`, payload)
+      setTodos(prev => [...prev, created])
+      setNewTodo({ title: '', description: '', category: 'PHYSICAL',
+                   weight: 1, dueAt: '' })
+      setDialogOpen(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create todo')
+    }
+  }
+
+  async function completeTodo(todoId: number) {
+    try {
+      const updated = await api.put<Todo>(
+        `/users/${userId}/todos/${todoId}/complete`, {})
+      setTodos(prev => prev.map(t => t.id === todoId ? updated : t))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to complete todo')
+    }
+  }
+
+  async function deleteTodo(todoId: number) {
+    try {
+      await api.delete(`/users/${userId}/todos/${todoId}`)
+      setTodos(prev => prev.filter(t => t.id !== todoId))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete todo')
+    }
+  }
+
+  if (isLoading) {
+    return <p className='text-muted-foreground'>Loading todos...</p>
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {error && (
+        <div className='rounded-lg bg-red-50 border border-red-200 px-4 py-3'>
+          <p className='text-sm text-red-700'>{error}</p>
+        </div>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger asChild>
+          <Button className='w-fit'>
+            <Plus className='mr-2 h-4 w-4' /> Add To-Do
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New To-Do</DialogTitle>
+          </DialogHeader>
+          <TodoForm
+            value={newTodo}
+            onChange={setNewTodo}
+            onSubmit={createTodo}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {todos.length === 0 ? (
+        <EmptyState message='No to-dos yet. Add one to start!' />
+      ) : (
+        <div className='flex flex-col gap-3'>
+          {todos.map(todo => (
+            <TodoCard
+              key={todo.id}
+              todo={todo}
+              onComplete={() => void completeTodo(todo.id)}
+              onDelete={() => void deleteTodo(todo.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── form components ──────────────────────────────────────────────────────────
+// extracted so dialog content stays readable
+
+function HabitForm({
+  value,
+  onChange,
+  onSubmit,
+}: {
+  value: NewHabit
+  onChange: (v: NewHabit) => void
+  onSubmit: () => void
+}) {
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='habit-title'>Title</Label>
+        <Input
+          id='habit-title'
+          placeholder='Morning run, Read 20 pages...'
+          value={value.title}
+          onChange={e => onChange({ ...value, title: e.target.value })}
+        />
+      </div>
+
+      {/* optional description */}
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='habit-desc'>Description (optional)</Label>
+        <Input
+          id='habit-desc'
+          placeholder='More details...'
+          value={value.description}
+          onChange={e => onChange({ ...value, description: e.target.value })}
+        />
+      </div>
+
+      {/* habit category for character stats */}
+      <div className='flex flex-col gap-1.5'>
+        <Label>Category</Label>
+        <Select
+          value={value.category}
+          onValueChange={v => onChange({ ...value, category: v as HabitCategory })}
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value='PHYSICAL'>
+              <div className="flex items-center gap-2"><Flame className="h-4 w-4 text-rose-500" /> Physical (levelling Strength)</div>
+            </SelectItem>
+            <SelectItem value='COGNITIVE'>
+              <div className="flex items-center gap-2"><Brain className="h-4 w-4 text-sky-500" /> Cognitive (levelling Intelligence)</div>
+            </SelectItem>
+            <SelectItem value='EMOTIONAL'>
+              <div className="flex items-center gap-2"><Heart className="h-4 w-4 text-emerald-500" /> Emotional (levelling Resilience)</div>
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* habit frequency */}
+      <div className='flex flex-col gap-1.5'>
+        <Label>Frequency</Label>
+        <Select
+          value={value.frequency}
+          onValueChange={v => onChange({ ...value, frequency: v as HabitFrequency })}
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value='DAILY'>Daily</SelectItem>
+            <SelectItem value='WEEKLY'>Weekly</SelectItem>
+            <SelectItem value='MONTHLY'>Monthly</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* positive/negative */}
+      <div className='flex flex-col gap-1.5'>
+        <Label>Type</Label>
+        <div className='flex gap-3'>
+          <button
+            type='button'
+            onClick={() => onChange({ ...value, positive: true })}
+            className={`flex-1 rounded-lg py-2 text-sm font-medium border transition-colors
+              ${value.positive
+                ? 'bg-green-500 text-white border-green-500'
+                : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted'
+              }`}
+          >
+            <Plus className="h-4 w-4" /> Positive
+          </button>
+          <button
+            type='button'
+            onClick={() => onChange({ ...value, positive: false })}
+            className={`flex-1 rounded-lg py-2 text-sm font-medium border transition-colors
+              ${!value.positive
+                ? 'bg-amber-500 text-white border-amber-500'
+                : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted'
+              }`}
+          >
+            <Minus className="h-4 w-4" /> Negative
+          </button>
+        </div>
+      </div>
+
+      {/* weight (difficulty) for amount of XP */}
+      <div className='flex flex-col gap-1.5'>
+        <Label>Difficulty</Label>
+        <div className='flex gap-2'>
+          {[1, 2, 3].map(w => (
+            <button
+              key={w}
+              type='button'
+              onClick={() => onChange({ ...value, weight: w })}
+              className={`flex-1 rounded-lg py-2 text-sm font-medium border transition-colors
+                ${value.weight === w
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted'
+                }`}
+            >
+              {weightLabel(w)}
+            </button>
+          ))}
+        </div>
+      </div>
+      
+      <button
+        onClick={onSubmit}
+        disabled={!value.title.trim()}
+        className='w-full rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground
+          hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
+      >
+        Create Habit
+      </button>
+    </div>
+  )
+}
+
+function TodoForm({
+  value,
+  onChange,
+  onSubmit,
+}: {
+  value: NewTodo
+  onChange: (v: NewTodo) => void
+  onSubmit: () => void
+}) {
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='todo-title'>Title</Label>
+        <Input
+          id='todo-title'
+          placeholder='Schedule dentist, Buy groceries...'
+          value={value.title}
+          onChange={e => onChange({ ...value, title: e.target.value })}
+        />
+      </div>
+
+      {/* optional description */}
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='todo-desc'>Description (optional)</Label>
+        <Input
+          id='todo-desc'
+          placeholder='More details...'
+          value={value.description}
+          onChange={e => onChange({ ...value, description: e.target.value })}
+        />
+      </div>
+
+      {/* todo category for character stats */}
+      <div className='flex flex-col gap-1.5'>
+        <Label>Category</Label>
+        <Select
+          value={value.category}
+          onValueChange={v => onChange({ ...value, category: v as HabitCategory })}
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value='PHYSICAL'>
+              <div className="flex items-center gap-2"><Flame className="h-4 w-4 text-rose-500" /> Physical (levelling Strength)</div>
+            </SelectItem>
+            <SelectItem value='COGNITIVE'>
+              <div className="flex items-center gap-2"><Brain className="h-4 w-4 text-sky-500" /> Cognitive (levelling Intelligence)</div>
+            </SelectItem>
+            <SelectItem value='EMOTIONAL'>
+              <div className="flex items-center gap-2"><Heart className="h-4 w-4 text-emerald-500" /> Emotional (levelling Resilience)</div>
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* weight (difficulty) for amount of XP */}
+      <div className='flex flex-col gap-1.5'>
+        <Label>Difficulty</Label>
+        <div className='flex gap-2'>
+          {[1, 2, 3].map(w => (
+            <button
+              key={w}
+              type='button'
+              onClick={() => onChange({ ...value, weight: w })}
+              className={`flex-1 rounded-lg py-2 text-sm font-medium border transition-colors
+                ${value.weight === w
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted'
+                }`}
+            >
+              {weightLabel(w)}
+            </button>
+          ))}
+        </div>
+      </div>
+      
+      {/* todo due date */}
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='todo-due'>Due Date (optional)</Label>
+        <Input
+          id='todo-due'
+          type='date'
+          value={value.dueAt}
+          onChange={e => onChange({ ...value, dueAt: e.target.value })}
+        />
+      </div>
+
+      <button
+        onClick={onSubmit}
+        disabled={!value.title.trim()}
+        className='w-full rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground
+          hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
+      >
+        Create To-Do
+      </button>
+    </div>
+  )
+}
+
+//display when no habits/todos created yet
+function EmptyState({ message }: { message: string }) {
+  return (
+    <Card>
+      <CardContent className='flex items-center justify-center py-12'>
+        <p className='text-muted-foreground text-sm'>{message}</p>
+      </CardContent>
+    </Card>
   )
 }

--- a/app/app/page.client.tsx
+++ b/app/app/page.client.tsx
@@ -8,6 +8,7 @@ import BossRaidPage from './boss-raid'
 import CharacterPage from './character'
 import Dashboard from './dashboard'
 import GroupsPage from './groups'
+import HabitsPage from './habits'
 import LeaderboardPage from './leaderboard'
 
 export default function ClientApplicationPage({ weatherCode }: { weatherCode: number | null }) {
@@ -28,6 +29,8 @@ export default function ClientApplicationPage({ weatherCode }: { weatherCode: nu
         </header>
         <div className='flex flex-1 flex-col gap-6 p-4 pt-0'>
           {currentPage === 'dashboard' && <Dashboard weatherCode={weatherCode} />}
+
+          {currentPage === 'habits' && <HabitsPage />}
 
           {currentPage === 'character' && <CharacterPage />}
 

--- a/components/habit-card.tsx
+++ b/components/habit-card.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { type Habit, categoryLabel, weightLabel } from '@/types/task'
+import { Brain, Check, Flame, Heart, Trash2 } from 'lucide-react'
+
+
+interface HabitCardProps {
+  habit: Habit
+  onComplete: () => void
+  onDelete: () => void
+}
+
+
+function CategoryIcon({ category }: { category: Habit['category'] }) {
+  switch (category) {
+    case 'PHYSICAL':  return <Flame className='h-4 w-4 text-rose-500' />
+    case 'COGNITIVE': return <Brain className='h-4 w-4 text-sky-500' />
+    case 'EMOTIONAL': return <Heart className='h-4 w-4 text-emerald-500' />
+  }
+}
+
+
+function StreakPanel({ habit }: { habit: Habit }) {
+  return (
+    <div className='flex flex-col items-center gap-3 rounded-lg bg-muted/40 p-4 min-w-30'>
+      <div className='flex w-full items-center justify-between gap-2'>
+        <span className='font-semibold text-sm'>Streak</span>
+        <span className='rounded bg-orange-500 px-1.5 py-0.5 text-xs font-bold text-white'>
+         {habit.streak}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+
+export function HabitCard({ habit, onComplete, onDelete }: HabitCardProps) {
+  return (
+    <Card className={habit.completed ? 'opacity-60' : ''}>
+      <CardHeader className='pb-2'>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <CategoryIcon category={habit.category} />
+            <CardTitle className={`text-base font-bold ${habit.completed ? 'line-through' : ''}`}>
+              {habit.title}
+            </CardTitle>
+          </div>
+
+          {/* positive/negative  */}
+          <span
+            className={`rounded-full px-2.5 py-0.5 text-xs font-medium border ${
+              habit.positive
+                ? 'bg-green-100 text-green-700 border-green-300'
+                : 'bg-amber-100 text-amber-700 border-amber-300'
+            }`}
+          >
+            {habit.positive ? 'Positive' : 'Negative'}
+          </span>
+        </div>
+
+        {habit.description && (
+          <CardDescription>{habit.description}</CardDescription>
+        )}
+      </CardHeader>
+
+      <CardContent>
+        <div className='grid grid-cols-[1fr_auto] gap-4 items-start'>
+          {/* left part: details + actions */}
+          <div className='flex flex-col gap-3'>
+            {/* data for category, weight and frequency */}
+            <div className='flex items-center gap-2 text-xs text-muted-foreground'>
+              <span className='rounded bg-muted px-2 py-0.5 font-medium'>
+                {categoryLabel(habit.category)}
+              </span>
+              <span>·</span>
+              <span className='rounded bg-muted px-2 py-0.5 font-medium'>
+                {weightLabel(habit.weight)}
+              </span>
+              <span>·</span>
+              <span className='rounded bg-muted px-2 py-0.5 font-medium'>
+                {habit.frequency.charAt(0) + habit.frequency.slice(1).toLowerCase()}
+              </span>
+            </div>
+
+            {/* displaying amount of xp gained based on weight */}
+            <div className='rounded-lg bg-blue-500 border border-blue-100 px-3 py-2'>
+              <p className='text-xs font-semibold text-blue-100'>
+                Completes for {habit.weight * 10} base XP
+              </p>
+              <p className='text-xs text-blue-200'>
+                Weather multiplier applies on completion!
+              </p>
+            </div>
+
+            {/* due date if set */}
+            {habit.dueAt && !habit.completed && (
+              <p className='text-xs text-muted-foreground'>
+                Due: {new Date(habit.dueAt).toLocaleDateString()}
+              </p>
+            )}
+
+            {/* action buttons */}
+            <div className='flex items-center gap-3 mt-1'>
+              <button
+                onClick={onComplete}
+                disabled={habit.completed}
+                className={`flex h-9 w-9 items-center justify-center rounded-full text-white text-sm transition-colors
+                  ${habit.completed
+                    ? 'bg-muted text-muted-foreground cursor-not-allowed'
+                    : 'bg-green-500 hover:bg-green-600'
+                  }`}
+              >
+                <Check className='h-4 w-4' />
+              </button>
+
+              <button
+                onClick={onDelete}
+                className='flex h-9 w-9 items-center justify-center rounded-full border-2 border-red-400 text-red-500 text-sm hover:bg-red-50 transition-colors'
+              >
+                <Trash2 className='h-4 w-4' />
+              </button>
+
+              {habit.completed && (
+                <span className='text-xs font-medium text-green-600'>
+                  ✓ Completed
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* right part: streak panel */}
+          <StreakPanel habit={habit} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/todo-card.tsx
+++ b/components/todo-card.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { type Todo, categoryLabel, weightLabel } from '@/types/task'
+import { Brain, Check, ClipboardList, Flame, Heart, Trash2, CheckCircle2, AlertTriangle } from 'lucide-react'
+
+interface TodoCardProps {
+  todo: Todo
+  onComplete: () => void
+  onDelete: () => void
+}
+
+function CategoryIcon({ category }: { category: Todo['category'] }) {
+  switch (category) {
+    case 'PHYSICAL':  return <Flame className='h-4 w-4 text-rose-500' />
+    case 'COGNITIVE': return <Brain className='h-4 w-4 text-sky-500' />
+    case 'EMOTIONAL': return <Heart className='h-4 w-4 text-emerald-500' />
+  }
+}
+
+
+function DueDatePanel({ todo }: { todo: Todo }) {
+  const hasDueDate = Boolean(todo.dueAt)
+  const isOverdue = hasDueDate && !todo.completed &&
+    new Date(todo.dueAt!) < new Date()
+
+  return (
+    <div className='flex flex-col items-center gap-3 rounded-lg bg-muted/40 p-4 min-w-30'>
+      <div className='flex w-full items-center justify-between gap-2'>
+        <span className='font-semibold text-sm'>Due</span>
+        {isOverdue && (
+          <span className='rounded bg-red-500 px-1.5 py-0.5 text-xs font-bold text-white'>
+            Overdue
+          </span>
+        )}
+        {todo.completed && (
+          <span className='rounded bg-green-500 px-1.5 py-0.5 text-xs font-bold text-white'>
+            Done
+          </span>
+        )}
+      </div>
+
+      <div className='flex h-16 w-16 items-center justify-center rounded bg-muted text-2xl select-none'>
+        {todo.completed ? (
+          <CheckCircle2 className="h-8 w-8 text-green-500" />
+        ) : isOverdue ? (
+          <AlertTriangle className="h-8 w-8 text-red-500" />
+        ) : (
+          <ClipboardList className="h-8 w-8" />
+        )}
+      </div>
+
+      {hasDueDate ? (
+        <p className={`text-xs font-medium text-center ${isOverdue ? 'text-red-500' : 'text-muted-foreground'}`}>
+          {new Date(todo.dueAt!).toLocaleDateString('en-CH', {
+            day: 'numeric',
+            month: 'short',
+          })}
+        </p>
+      ) : (
+        <p className='text-xs text-muted-foreground text-center'>No due date</p>
+      )}
+    </div>
+  )
+}
+
+
+export function TodoCard({ todo, onComplete, onDelete }: TodoCardProps) {
+  return (
+    <Card className={todo.completed ? 'opacity-60' : ''}>
+      <CardHeader className='pb-2'>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <CategoryIcon category={todo.category} />
+            <CardTitle className={`text-base font-bold ${todo.completed ? 'line-through' : ''}`}>
+              {todo.title}
+            </CardTitle>
+          </div>
+
+          <span className='rounded-full px-2.5 py-0.5 text-xs font-medium border bg-purple-100 text-purple-700 border-purple-300'>
+            One-time
+          </span>
+        </div>
+
+        {todo.description && (
+          <CardDescription>{todo.description}</CardDescription>
+        )}
+      </CardHeader>
+
+      <CardContent>
+        <div className='grid grid-cols-[1fr_auto] gap-4 items-start'>
+          {/* left part: details + actions */}
+          <div className='flex flex-col gap-3'>
+            {/* data for category and weight */}
+            <div className='flex items-center gap-2 text-xs text-muted-foreground'>
+              <span className='rounded bg-muted px-2 py-0.5 font-medium'>
+                {categoryLabel(todo.category)}
+              </span>
+              <span>·</span>
+              <span className='rounded bg-muted px-2 py-0.5 font-medium'>
+                {weightLabel(todo.weight)}
+              </span>
+            </div>
+
+            {/* displaying amount of xp gained based on weight */}
+            <div className='rounded-lg bg-purple-50 border border-purple-200 px-3 py-2'>
+              <p className='text-xs font-semibold text-purple-800'>
+                Completes for {todo.weight * 10} XP
+              </p>
+              <p className='text-xs text-purple-600'>
+                One-time reward — no weather multiplier
+              </p>
+            </div>
+
+            {/* action buttons */}
+            <div className='flex items-center gap-3 mt-1'>
+              <button
+                onClick={onComplete}
+                disabled={todo.completed}
+                className={`flex h-9 w-9 items-center justify-center rounded-full text-white text-sm transition-colors
+                  ${todo.completed
+                    ? 'bg-muted text-muted-foreground cursor-not-allowed'
+                    : 'bg-green-500 hover:bg-green-600'
+                  }`}
+              >
+                <Check className='h-4 w-4' />
+              </button>
+
+              <button
+                onClick={onDelete}
+                className='flex h-9 w-9 items-center justify-center rounded-full border-2 border-red-400 text-red-500 text-sm hover:bg-red-50 transition-colors'
+              >
+                <Trash2 className='h-4 w-4' />
+              </button>
+
+              {todo.completed && (
+                <span className='text-xs font-medium text-green-600'>
+                  ✓ Completed
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* right part: due date panel */}
+          <DueDatePanel todo={todo} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-xs/relaxed text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-2 right-2"
+              size="icon-sm"
+            >
+              <XIcon
+              />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-xs/relaxed text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-md border border-input bg-input/20 px-2 py-1.5 text-xs/relaxed whitespace-nowrap transition-colors outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-7 data-[size=sm]:h-6 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="pointer-events-none size-3.5 text-muted-foreground" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
+        className={cn("z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          data-position={position}
+          className={cn(
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && ""
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex min-h-7 w-full cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn(
+        "pointer-events-none -mx-1 my-1 h-px bg-border/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-3.5",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-3.5",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/types/task.ts
+++ b/types/task.ts
@@ -1,0 +1,73 @@
+export type HabitCategory = 'PHYSICAL' | 'COGNITIVE' | 'EMOTIONAL'
+export type HabitFrequency = 'DAILY' | 'WEEKLY' | 'MONTHLY'
+
+export type Habit = {
+  id: number
+  title: string
+  description?: string
+  category: HabitCategory
+  frequency: HabitFrequency
+  positive: boolean
+  weight: number
+  completed: boolean
+  streak: number
+  dueAt?: string
+  completedAt?: string
+  createdAt: string
+}
+
+export type Todo = {
+  id: number
+  title: string
+  description?: string
+  category: HabitCategory
+  weight: number
+  completed: boolean
+  dueAt?: string
+  completedAt?: string
+  createdAt: string
+}
+
+export type NewHabit = {
+  title: string
+  description: string
+  category: HabitCategory
+  frequency: HabitFrequency
+  positive: boolean
+  weight: number
+}
+
+export type NewTodo = {
+  title: string
+  description: string
+  category: HabitCategory
+  weight: number
+  dueAt: string
+}
+
+//helper functions for habti and todo cards
+
+export function categoryLabel(category: HabitCategory): string {
+  switch (category) {
+    case 'PHYSICAL':  return 'Strength'
+    case 'COGNITIVE': return 'Intelligence'
+    case 'EMOTIONAL': return 'Resilience'
+  }
+}
+
+export function weightLabel(weight: number): string {
+  switch (weight) {
+    case 1:  return 'Easy'
+    case 2:  return 'Medium'
+    case 3:  return 'Hard'
+    default: return 'Easy'
+  }
+}
+
+export function categoryColor(category: HabitCategory): string {
+  switch (category) {
+    case 'PHYSICAL':  return 'text-rose-500'
+    case 'COGNITIVE': return 'text-sky-500'
+    case 'EMOTIONAL': return 'text-emerald-500'
+  }
+}


### PR DESCRIPTION
implemented frontend dashboard for managing tasks (habits and todos) with shadcn dialog + select.
users can now create new habits/todos when navigating to habits/todos in the sidebar. then they can either mark it as complete (-> triggers PUT request for xp) or delete the habit (-> DELETE request). using dynamic data fetching with useApi hook to load user specific tasks on mount.
adhering to our prior design pattern by splitting UI into a main container (index.tsx) and new reusable components (habit-card.tsx + todo-card.tsx)