### PR TITLE
Fix/boss raid design

### DIFF
--- a/app/app/boss-raid/member-health-bar.tsx
+++ b/app/app/boss-raid/member-health-bar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Badge } from '@/components/ui/badge'
 import { RaidMemberData } from '@/types/raids'
 import { useEffect, useRef } from 'react'
 
@@ -10,7 +11,13 @@ export function MemberHealthBar({ member, isCurrentUser }: { member: RaidMemberD
   const isDead = maxHp > 0 && hp <= 0
   const barRef = useRef<HTMLDivElement>(null)
 
-  const barColor = isDead ? 'bg-muted-foreground/40' : percent <= 25 ? 'bg-red-500' : percent <= 50 ? 'bg-yellow-400' : 'bg-green-500'
+  const barColor = isDead
+    ? 'bg-muted-foreground/40'
+    : percent <= 25
+      ? 'bg-red-500'
+      : percent <= 50
+        ? 'bg-yellow-400'
+        : 'bg-green-500'
 
   useEffect(() => {
     if (barRef.current) {
@@ -19,19 +26,25 @@ export function MemberHealthBar({ member, isCurrentUser }: { member: RaidMemberD
   }, [percent])
 
   return (
-    <div className={`rounded-lg px-3 py-2 ${isDead ? 'opacity-60' : ''} ${isCurrentUser ? 'bg-primary/5' : 'bg-card'}`}>
-      <div className='flex items-center justify-between mb-1'>
-        <span className={`text-xs font-medium truncate ${isCurrentUser ? 'text-primary' : ''}`}>
+    <div
+      className={`flex flex-col gap-1 rounded-lg px-3 py-2 ${isDead ? 'opacity-60' : ''} ${
+        isCurrentUser ? 'bg-primary/5' : 'bg-card'
+      }`}
+    >
+      <div className='flex items-center justify-between gap-2'>
+        <span className={`truncate text-xs font-medium ${isCurrentUser ? 'text-primary' : ''}`}>
           {member.username}
           {isCurrentUser && ' (you)'}
         </span>
         {isDead ? (
-          <span className='ml-2 shrink-0 rounded px-1.5 py-0.5 text-xs font-bold bg-destructive/15 text-destructive'>KO</span>
+          <Badge variant='destructive'>K/O</Badge>
         ) : (
-          <span className='text-xs ml-2 shrink-0'>{hp}/{maxHp}</span>
+          <span className='shrink-0 text-xs tabular-nums'>
+            {hp}/{maxHp}
+          </span>
         )}
       </div>
-      <div className='h-2 w-full rounded-full bg-muted overflow-hidden'>
+      <div className='h-2 w-full overflow-hidden rounded-full bg-muted'>
         <div ref={barRef} className={`h-full rounded-full transition-all duration-500 ${barColor}`} />
       </div>
     </div>

--- a/app/app/boss-raid/raid-view.tsx
+++ b/app/app/boss-raid/raid-view.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { RaidData, RaidTaskData } from '@/types/raids'
 import { RaidCard } from '@/components/raid-card'
 import { Button } from '@/components/ui/button'
-import { MemberHealthBar } from './member-health-bar'
-import { TaskCard } from './task-card'
-import { assignedTasks, getActiveTask, getUpcomingTasks, raidStatusToState, sortRaidUsers, toRaidCard } from './utils'
+import { Card, CardContent } from '@/components/ui/card'
+import { RaidData, RaidTaskData } from '@/types/raids'
 import { Check } from 'lucide-react'
+import { TaskCard } from './task-card'
+import { assignedTasks, getActiveTask, getUpcomingTasks, raidStatusToState, toRaidCard } from './utils'
 
 export function RaidView({
   raid,
@@ -31,7 +31,6 @@ export function RaidView({
   const upcomingTasks = state === 'active' ? getUpcomingTasks(tasks, uid, raid.startedAt, activeTask) : []
   const myDone = assignedTasks(tasks, uid).filter((task) => (task.successfullyCompletedByUsers ?? []).includes(uid))
   const allMyTasks = assignedTasks(tasks, uid)
-  const orderedUsers = sortRaidUsers(raid.users ?? [])
 
   return (
     <div className='flex flex-col gap-4'>
@@ -40,19 +39,6 @@ export function RaidView({
       {state === 'lobby' && !isJoined && (
         <div className='flex justify-center'>
           <Button onClick={onJoin}>Join Raid</Button>
-        </div>
-      )}
-
-      {state === 'active' && (
-        <div className='flex flex-col gap-2'>
-          <p className='text-sm font-semibold'>Team Health</p>
-          <div className='grid grid-cols-1 gap-2 sm:grid-cols-2'>
-            {orderedUsers
-              .filter((user) => user.joined)
-              .map((user) => (
-                <MemberHealthBar key={user.userId} member={user} isCurrentUser={user.userId === uid} />
-              ))}
-          </div>
         </div>
       )}
 
@@ -73,35 +59,33 @@ export function RaidView({
 
           {upcomingTasks.length > 0 && (
             <div className='flex flex-col gap-2'>
-              <p className='text-xs font-medium text-muted-foreground uppercase tracking-wide'>Upcoming</p>
+              <p className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>Upcoming</p>
               {upcomingTasks.map((task) => (
-                <div key={task.id} className='flex items-center gap-3 rounded-lg border bg-muted/20 px-4 py-3 opacity-60'>
-                  <div className='flex-1 min-w-0'>
+                <Card key={task.id} className='opacity-60'>
+                  <CardContent>
                     <p className='text-sm font-medium text-muted-foreground'>{task.title}</p>
                     {task.timeLimitSeconds != null && (
                       <p className='text-xs text-muted-foreground'>
                         {task.timeLimitSeconds}s time, {task.successfulDamage ?? 0} damage dealt
                       </p>
                     )}
-                  </div>
-                </div>
+                  </CardContent>
+                </Card>
               ))}
             </div>
           )}
 
           {myDone.map((task) => (
-            <div key={task.id} className='flex items-center gap-3 rounded-lg border bg-muted/40 px-4 py-3 opacity-60'>
-              <span className='flex size-7 shrink-0 items-center justify-center rounded-full bg-green-500'>
-                <Check className='size-4' />
-              </span>
-              <p className='text-sm line-through text-muted-foreground'>{task.title}</p>
-            </div>
+            <Card key={task.id} className='opacity-60'>
+              <CardContent className='flex items-center gap-3'>
+                <Check className='size-4 text-emerald-600' />
+                <p className='text-sm text-muted-foreground line-through'>{task.title}</p>
+              </CardContent>
+            </Card>
           ))}
 
           {activeTask == null && upcomingTasks.length === 0 && myDone.length > 0 && (
-            <p className='text-center text-sm text-green-600 font-medium'>
-              Congratulations! all your tasks are done, waiting for teammates…
-            </p>
+            <p className='text-center text-sm font-medium text-emerald-600'>All your tasks are done — waiting for teammates…</p>
           )}
         </div>
       )}

--- a/app/app/boss-raid/task-card.tsx
+++ b/app/app/boss-raid/task-card.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { RaidTaskData } from '@/types/raids'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { RaidTaskData } from '@/types/raids'
 import { Check } from 'lucide-react'
 import { taskWindowSecondsLeft } from './utils'
 
@@ -15,38 +17,29 @@ export function TaskCard({
   onSuccess: () => void
 }) {
   const secsLeft = Math.max(0, taskWindowSecondsLeft(task, startedAt))
-  const minutes = String(Math.floor(secsLeft / 60)).padStart(2, '0')
-  const seconds = String(secsLeft % 60).padStart(2, '0')
+  const hasTimer = task.timeLimitSeconds != null && task.timeLimitSeconds > 0
+  const percentLeft = hasTimer ? Math.max(0, Math.min(100, (secsLeft / task.timeLimitSeconds!) * 100)) : 0
+  const isLow = hasTimer && percentLeft <= 25
 
   return (
-    <div className='flex items-start gap-4 rounded-lg border bg-card px-4 py-3'>
-      <div className='flex-1 min-w-0'>
-        <div className='flex items-center justify-between gap-2'>
-          <p className='text-sm font-medium'>{task.title}</p>
-          {task.timeLimitSeconds != null && (
-            <span className={`text-xs font-mono font-semibold tabular-nums text-destructive animate-pulse`}>
-              {minutes}:{seconds}
-            </span>
-          )}
+    <Card>
+      <CardContent className='flex flex-col gap-3'>
+        <div className='flex items-start gap-4'>
+          <div className='flex min-w-0 flex-1 flex-col gap-1'>
+            <p className='text-sm font-medium'>{task.title}</p>
+            {task.description && <p className='text-xs text-muted-foreground'>{task.description}</p>}
+            <div className='flex gap-3 text-xs'>
+              <span className='font-medium text-emerald-600'>+{task.successfulDamage ?? 0} damage to boss</span>
+              {(task.groupDamage ?? 0) > 0 && <span className='text-destructive'>{task.groupDamage} group damage</span>}
+            </div>
+          </div>
+          <Button size='sm' onClick={onSuccess} title='Mark as done' className='self-center'>
+            <Check />
+            Done
+          </Button>
         </div>
-        {task.description && <p className='text-xs text-muted-foreground mt-0.5'>{task.description}</p>}
-        <div className='flex gap-3 mt-1.5 text-xs'>
-          <span className='text-green-600 font-medium'>+{task.successfulDamage ?? 0} damage to boss</span>
-          {(task.groupDamage ?? 0) > 0 && <span className='text-destructive'>{task.groupDamage} group damage</span>}
-        </div>
-      </div>
-      <div className='flex shrink-0 items-center self-center'>
-        <Button
-          variant='outline'
-          size='sm'
-          onClick={onSuccess}
-          title='Mark as done'
-          className='h-8 gap-1.5 rounded-full px-3 text-green-700 shadow-sm transition-all  hover:bg-green-100 hover:text-green-800'
-        >
-          <Check className='size-4' />
-          <span className='text-xs font-medium'>Done</span>
-        </Button>
-      </div>
-    </div>
+        {hasTimer && <Progress value={percentLeft} innerClassName={isLow ? 'bg-destructive' : 'bg-primary'} />}
+      </CardContent>
+    </Card>
   )
 }

--- a/app/app/boss-raid/utils.ts
+++ b/app/app/boss-raid/utils.ts
@@ -101,6 +101,8 @@ export function toRaidCard(raid: RaidData, currentUserId: number | string | unde
         name: member.username,
         isCurrentUser,
         characterType: member.characterType ?? null,
+        health: member.health,
+        maxHealth: member.maxHealth,
         status: member.joined ? 'Ready' : onlineUserIds.has(member.userId) ? 'Pending' : 'Offline',
       }
     }
@@ -111,6 +113,8 @@ export function toRaidCard(raid: RaidData, currentUserId: number | string | unde
         name: member.username,
         isCurrentUser,
         characterType: member.characterType ?? null,
+        health: member.health,
+        maxHealth: member.maxHealth,
         status: 'Ready',
         taskDescription: nextTask ? nextTask.title : 'All tasks done!',
         taskDamage: nextTask?.successfulDamage,

--- a/components/raid-card.tsx
+++ b/components/raid-card.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
 import { motion, useAnimate } from 'framer-motion'
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
-import { Badge } from './ui/badge'
 
 export type RaidState = 'lobby' | 'active' | 'defeat' | 'victory'
 export type MemberStatus = 'Ready' | 'Offline' | 'Pending'
@@ -23,27 +23,8 @@ export interface RaidMember {
   totalTasks?: number
   xpChange?: number
   died?: boolean
-}
-
-function CharacterAvatar({ member }: { member: RaidMember }) {
-  if (member.characterType) {
-    return (
-      <div className='size-10 shrink-0 flex items-center justify-center rounded-full bg-muted overflow-hidden'>
-        <Image
-          src={`/characters/${member.characterType}/rotations/south.png`}
-          alt={member.name}
-          width={40}
-          height={40}
-          style={{ imageRendering: 'pixelated' }}
-        />
-      </div>
-    )
-  }
-  return (
-    <Avatar size={'default'}>
-      <AvatarFallback>{member.name[0]}</AvatarFallback>
-    </Avatar>
-  )
+  health?: number | null
+  maxHealth?: number | null
 }
 
 export interface Monster {
@@ -70,13 +51,82 @@ export interface BossRaid {
   reward?: string
 }
 
-const STATUS_STYLES: Record<MemberStatus, string> = {
-  Ready: 'bg-green-100 text-green-700 border border-green-300',
-  Offline: 'bg-red-100   text-red-600   border border-red-300',
-  Pending: 'bg-yellow-100 text-yellow-700 border border-yellow-300',
+const STATUS_VARIANT: Record<MemberStatus, 'default' | 'secondary' | 'destructive'> = {
+  Ready: 'default',
+  Offline: 'destructive',
+  Pending: 'secondary',
 }
 
-function MonsterPanel({ monster }: { monster: Monster }) {
+function CharacterImage({
+  characterType,
+  alt,
+  size,
+  rotation = 'south',
+}: {
+  characterType?: string | null
+  alt: string
+  size: number
+  rotation?: 'south' | 'east' | 'west' | 'north'
+}) {
+  if (!characterType) {
+    return (
+      <Avatar size='lg'>
+        <AvatarFallback>{alt[0]}</AvatarFallback>
+      </Avatar>
+    )
+  }
+  return (
+    <Image
+      src={`/characters/${characterType}/rotations/${rotation}.png`}
+      alt={alt}
+      width={size}
+      height={size}
+      style={{ imageRendering: 'pixelated' }}
+    />
+  )
+}
+
+function MemberSprite({ member, dim = false }: { member: RaidMember; dim?: boolean }) {
+  const hp = member.health
+  const maxHp = member.maxHealth
+  const hasHp = hp != null && maxHp != null && maxHp > 0
+  const percent = hasHp ? Math.max(0, Math.min(100, (hp / maxHp) * 100)) : 0
+  const isDead = hasHp && hp <= 0
+  const barColor = isDead
+    ? 'bg-muted-foreground/40'
+    : percent <= 25
+      ? 'bg-red-500'
+      : percent <= 50
+        ? 'bg-yellow-400'
+        : 'bg-green-500'
+
+  return (
+    <div className={`flex w-24 flex-col items-center gap-1 ${dim || isDead ? 'opacity-40 grayscale' : ''}`} title={member.name}>
+      <CharacterImage characterType={member.characterType} alt={member.name} size={88} rotation='north' />
+      <span className={`text-[10px] ${member.isCurrentUser ? 'font-semibold text-primary' : 'text-muted-foreground'}`}>
+        {member.isCurrentUser ? 'You' : member.name}
+      </span>
+      {hasHp && (
+        <>
+          <Progress value={percent} className='h-1.5 w-full' innerClassName={barColor} />
+          <span className='text-[9px] tabular-nums text-muted-foreground'>{isDead ? 'KO' : `${hp}/${maxHp}`}</span>
+        </>
+      )}
+    </div>
+  )
+}
+
+function BossStage({
+  monster,
+  members,
+  dim = false,
+  dimDeadMembers = false,
+}: {
+  monster: Monster
+  members: RaidMember[]
+  dim?: boolean
+  dimDeadMembers?: boolean
+}) {
   const [scope, animate] = useAnimate()
   const prevHpRef = useRef<number | undefined>(undefined)
   const [damage, setDamage] = useState<number | null>(null)
@@ -84,39 +134,43 @@ function MonsterPanel({ monster }: { monster: Monster }) {
 
   useEffect(() => {
     if (monster.hp === undefined) return
-
     const prevHp = prevHpRef.current
     prevHpRef.current = monster.hp
-
     if (prevHp === undefined || monster.hp >= prevHp) return
 
     setDamage(prevHp - monster.hp)
     setHitKey((k) => k + 1)
-
     animate(scope.current, { x: [-10, 10, -7, 7, -4, 4, 0] }, { duration: 0.45 })
     animate('.hit-overlay', { opacity: [0.75, 0] }, { duration: 0.4 })
   }, [monster.hp])
 
   return (
-    <div ref={scope} className='flex flex-col items-center gap-3 rounded-lg'>
-      <div className='flex w-full items-center justify-between gap-2'>
-        <span className='font-semibold text-sm'>{monster.name}</span>
-        <Badge variant={'destructive'}>LVL {monster.level}</Badge>
-      </div>
-      <p className='w-full text-xs text-muted-foreground'>{monster.description}</p>
-
-      <div className='relative'>
-        <div className='relative flex h-36 w-36 items-center justify-center overflow-hidden rounded bg-muted text-4xl select-none'>
-          <Image src={monster.imageUrl} alt={monster.name} width={144} height={144} />
-          <div className='hit-overlay pointer-events-none absolute inset-0 rounded bg-red-500 opacity-0' />
+    <div className='flex w-full flex-col gap-3 rounded-lg bg-linear-to-b from-muted/40 to-transparent p-4'>
+      <div className='flex items-center justify-between gap-2'>
+        <div className='flex flex-col'>
+          <span className='text-base font-semibold'>{monster.name}</span>
+          <span className='text-xs text-muted-foreground'>{monster.description}</span>
         </div>
+        <Badge variant='destructive'>LVL {monster.level}</Badge>
+      </div>
+
+      <div ref={scope} className='relative mx-auto flex flex-col items-center gap-2'>
+        <div
+          className={`relative flex size-56 items-center justify-center overflow-hidden rounded-lg bg-muted select-none ${
+            dim ? 'opacity-50' : ''
+          }`}
+        >
+          <Image src={monster.imageUrl} alt={monster.name} width={224} height={224} />
+          <div className='hit-overlay pointer-events-none absolute inset-0 rounded-lg bg-red-500 opacity-0' />
+        </div>
+        <Progress value={monster.hpPercent} className='h-2 w-56' innerClassName='bg-emerald-500' />
 
         {damage !== null && (
           <motion.div
             key={hitKey}
-            className='pointer-events-none absolute -top-6 left-1/2 -translate-x-1/2 select-none whitespace-nowrap text-xl font-bold text-red-500'
+            className='pointer-events-none absolute -top-6 left-1/2 -translate-x-1/2 select-none whitespace-nowrap text-2xl font-bold text-red-500'
             initial={{ opacity: 1, y: 0 }}
-            animate={{ opacity: 0, y: -40 }}
+            animate={{ opacity: 0, y: -50 }}
             transition={{ duration: 0.75, ease: 'easeOut' }}
             onAnimationComplete={() => setDamage(null)}
           >
@@ -125,7 +179,63 @@ function MonsterPanel({ monster }: { monster: Monster }) {
         )}
       </div>
 
-      <Progress value={monster.hpPercent} className='h-2 w-full' innerClassName='bg-green-500' />
+      <div className='flex justify-center gap-3 pt-2'>
+        {members.map((member, i) => {
+          const center = (members.length - 1) / 2
+          const t = center === 0 ? 0 : ((i - center) / center) ** 2
+          const dropPx = (1 - t) * 28
+          return (
+            <div key={member.name} style={{ transform: `translateY(${dropPx}px)` }}>
+              <MemberSprite member={member} dim={dimDeadMembers && !!member.died} />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function MembersCard({
+  title,
+  description,
+  members,
+  renderMember,
+}: {
+  title: string
+  description?: string
+  members: RaidMember[]
+  renderMember?: (member: RaidMember) => React.ReactNode
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent className='flex flex-col gap-2'>
+        {members.map((member) => (
+          <div key={member.name} className='flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2'>
+            <Avatar size='lg'>
+              <AvatarFallback>{member.name[0]}</AvatarFallback>
+            </Avatar>
+            <div className='flex min-w-0 flex-1 flex-col'>
+              <p className={`truncate text-sm font-medium ${member.isCurrentUser ? 'text-primary' : ''}`}>
+                {member.isCurrentUser ? 'You' : member.name}
+              </p>
+              {renderMember?.(member)}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function Layout({ left, right }: { left: React.ReactNode; right: React.ReactNode }) {
+  return (
+    <div className='grid gap-4 md:grid-cols-[18rem_1fr]'>
+      {left}
+      {right}
     </div>
   )
 }
@@ -134,33 +244,31 @@ function LobbyCard({ raid }: { raid: BossRaid }) {
   const readyCount = raid.members.filter((m) => m.status === 'Ready').length
 
   return (
-    <Card className='w-full'>
-      <CardHeader>
-        <CardTitle className='text-base font-bold'>{raid.groupName}</CardTitle>
-        <CardDescription>
-          {readyCount}/{raid.members.length} players ready!
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className='grid grid-cols-[1fr_auto_auto] gap-4 items-start'>
-          <div className='flex flex-col gap-2'>
-            {raid.members.map((member) => (
-              <div key={member.name} className='flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2'>
-                <CharacterAvatar member={member} />
-                <p className='flex-1 text-sm font-medium'>{member.isCurrentUser ? 'You' : member.name}</p>
-                <Badge className={STATUS_STYLES[member.status]}>{member.status}</Badge>
-              </div>
-            ))}
-          </div>
-
-          <div className='flex flex-col items-center justify-center gap-4 px-4 min-w-60'>
-            <p className='text-lg font-bold whitespace-nowrap'>Raid starts in {raid.raidStartsIn}</p>
-          </div>
-
-          <MonsterPanel monster={raid.monster} />
-        </div>
-      </CardContent>
-    </Card>
+    <Layout
+      left={
+        <MembersCard
+          title='Players'
+          description={`${readyCount}/${raid.members.length} ready`}
+          members={raid.members}
+          renderMember={(m) => (
+            <Badge variant={STATUS_VARIANT[m.status]} className='self-start'>
+              {m.status}
+            </Badge>
+          )}
+        />
+      }
+      right={
+        <Card>
+          <CardHeader>
+            <CardTitle>{raid.groupName}</CardTitle>
+            <CardDescription>Raid starts in {raid.raidStartsIn}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <BossStage monster={raid.monster} members={raid.members} />
+          </CardContent>
+        </Card>
+      }
+    />
   )
 }
 
@@ -168,130 +276,123 @@ function ActiveCard({ raid }: { raid: BossRaid }) {
   const pct = raid.timeLeftSeconds && raid.totalSeconds ? (raid.timeLeftSeconds / raid.totalSeconds) * 100 : 0
 
   return (
-    <Card className='w-full'>
-      <CardHeader>
-        <CardTitle>{raid.groupName}</CardTitle>
-        <CardDescription>{raid.playersOnline} players online</CardDescription>
-      </CardHeader>
-      <CardContent className='flex flex-col gap-4'>
-        <div className='grid grid-cols-[1fr_auto] gap-4 items-start'>
-          <div className='flex flex-col gap-2'>
-            {raid.members.map((member) => (
-              <div key={member.name} className='flex items-center gap-3 rounded-lg px-3 py-2'>
-                <CharacterAvatar member={member} />
-                <div className='flex-1 min-w-0'>
-                  <p className='text-sm font-medium'>{member.isCurrentUser ? 'You' : member.name}</p>
-                  <p className='text-xs text-muted-foreground truncate'>{member.taskDescription}</p>
-                </div>
-              </div>
-            ))}
-            <div className='flex items-center gap-2 mt-1'>
+    <Layout
+      left={
+        <MembersCard
+          title='Players'
+          description={`${raid.playersOnline} online`}
+          members={raid.members}
+          renderMember={(m) =>
+            m.taskDescription ? <p className='truncate text-xs text-muted-foreground'>{m.taskDescription}</p> : null
+          }
+        />
+      }
+      right={
+        <Card>
+          <CardHeader>
+            <CardTitle>{raid.groupName}</CardTitle>
+            <CardDescription>Battle in progress</CardDescription>
+          </CardHeader>
+          <CardContent className='flex flex-col gap-4'>
+            <BossStage monster={raid.monster} members={raid.members} />
+            <div className='flex items-center gap-2'>
               <Progress value={pct} className='h-2 flex-1' innerClassName='bg-orange-400' />
-              <Badge className='whitespace-nowrap' variant={'outline'}>
-                {raid.timeLeftSeconds ?? raid.totalSeconds ?? 0} seconds left
-              </Badge>
+              <Badge variant='outline'>{raid.timeLeftSeconds ?? raid.totalSeconds ?? 0}s left</Badge>
             </div>
-          </div>
-
-          <MonsterPanel monster={raid.monster} />
-        </div>
-      </CardContent>
-    </Card>
+          </CardContent>
+        </Card>
+      }
+    />
   )
 }
 
 function DefeatCard({ raid }: { raid: BossRaid }) {
   return (
-    <Card className='w-full'>
-      <CardHeader>
-        <CardTitle className='text-base font-bold'>
-          Monster won — <span className='text-destructive'>you lost!</span>
-        </CardTitle>
-        <CardDescription>{raid.playersOnline} players online</CardDescription>
-      </CardHeader>
-      <CardContent className='flex flex-col gap-4'>
-        <div className='grid grid-cols-[1fr_auto] gap-4 items-start'>
-          <div className='flex flex-col gap-2'>
-            {raid.members.map((member) => (
-              <div key={member.name} className='flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2'>
-                <CharacterAvatar member={member} />
-                <div className='flex-1 min-w-0'>
-                  <div className='flex items-center gap-2'>
-                    <p className='text-sm font-medium'>{member.isCurrentUser ? 'You' : member.name}</p>
-                    {member.died && <span className='rounded-full bg-destructive px-2 py-0.5 text-xs font-bold'>died!</span>}
-                  </div>
-                  <p className='text-xs text-muted-foreground'>
-                    {member.tasksCompleted}/{member.totalTasks} tasks completed
-                  </p>
-                </div>
-                <span className='text-xs font-medium text-destructive whitespace-nowrap'>{member.xpChange} XP</span>
-              </div>
-            ))}
-          </div>
-
-          <div className='flex flex-col items-center gap-3 rounded-lg bg-muted/40 p-4 min-w-45'>
-            <div className='text-2xl font-bold text-muted-foreground italic'>Bwahahaha</div>
-            <div className='flex h-36 w-36 items-center justify-center rounded bg-muted text-4xl select-none'>
-              <Image src={raid.monster.imageUrl} alt={raid.monster.name} width={144} height={144} />
+    <Layout
+      left={
+        <MembersCard
+          title='Players'
+          description={`${raid.playersOnline} online`}
+          members={raid.members}
+          renderMember={(m) => (
+            <div className='flex items-center gap-2'>
+              {m.died && <Badge variant='destructive'>Died</Badge>}
+              <p className='text-xs text-muted-foreground'>
+                {m.tasksCompleted}/{m.totalTasks} tasks
+              </p>
+              <p className='ml-auto text-xs font-medium text-destructive'>{m.xpChange} XP</p>
             </div>
-            <Progress value={raid.monster.hpPercent} className='h-2 w-full' innerClassName='bg-green-500' />
-          </div>
-        </div>
-
-        {raid.reward && (
-          <div className='flex items-center justify-center gap-3 rounded-lg bg-muted/50 px-6 py-3 self-center'>
-            <span className='text-sm font-semibold'>You missed a:</span>
-            <div className='flex h-10 w-10 items-center justify-center rounded bg-muted text-xl'>{raid.reward}</div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          )}
+        />
+      }
+      right={
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Monster won — <span className='text-destructive'>you lost!</span>
+            </CardTitle>
+            <CardDescription className='text-2xl font-bold italic'>Bwahahaha</CardDescription>
+          </CardHeader>
+          <CardContent className='flex flex-col gap-4'>
+            <BossStage monster={raid.monster} members={raid.members} dimDeadMembers />
+            {raid.reward && (
+              <div className='flex items-center justify-center gap-3 self-center rounded-lg bg-muted/50 px-6 py-3'>
+                <span className='text-sm font-semibold'>You missed a:</span>
+                <div className='flex size-10 items-center justify-center rounded bg-muted text-xl'>{raid.reward}</div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      }
+    />
   )
 }
 
 function VictoryCard({ raid }: { raid: BossRaid }) {
+  const defeatedMonster: Monster = {
+    ...raid.monster,
+    imageUrl: '/characters/bosses/innereschweinehund.png',
+    name: 'Innere Schweinehund',
+    hpPercent: 0,
+  }
+
   return (
-    <Card className='w-full'>
-      <CardHeader>
-        <CardTitle className='text-base font-bold'>
-          Monster lost — <span className='text-green-500'>you win!</span>
-        </CardTitle>
-        <CardDescription>{raid.playersOnline} players online</CardDescription>
-      </CardHeader>
-      <CardContent className='flex flex-col gap-4'>
-        <div className='grid grid-cols-[1fr_auto] gap-4 items-start'>
-          <div className='flex flex-col gap-2'>
-            {raid.members.map((member) => (
-              <div key={member.name} className='flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2'>
-                <CharacterAvatar member={member} />
-                <div className='flex-1 min-w-0'>
-                  <p className='text-sm font-medium'>{member.isCurrentUser ? 'You' : member.name}</p>
-                  <p className='text-xs text-muted-foreground'>
-                    {member.tasksCompleted}/{member.totalTasks} tasks completed
-                  </p>
-                </div>
-                <span className='text-xs font-medium text-green-600 whitespace-nowrap'>+{member.xpChange} XP</span>
-              </div>
-            ))}
-          </div>
-
-          <div className='flex flex-col items-center gap-3 rounded-lg bg-muted/40 p-4 min-w-45'>
-            <div className='text-2xl font-bold text-muted-foreground italic'>Argh!</div>
-            <div className='flex h-36 w-36 items-center justify-center rounded bg-muted text-4xl select-none opacity-50'>
-              <Image src='/characters/bosses/innereschweinehund.png' alt={'Innere Scheinehund'} width={144} height={144} />
+    <Layout
+      left={
+        <MembersCard
+          title='Players'
+          description={`${raid.playersOnline} online`}
+          members={raid.members}
+          renderMember={(m) => (
+            <div className='flex items-center gap-2'>
+              <p className='text-xs text-muted-foreground'>
+                {m.tasksCompleted}/{m.totalTasks} tasks
+              </p>
+              <p className='ml-auto text-xs font-medium text-emerald-600'>+{m.xpChange} XP</p>
             </div>
-            <Progress value={raid.monster.hpPercent} className='h-2 w-full' innerClassName='bg-green-500' />
-          </div>
-        </div>
-
-        {raid.reward && (
-          <div className='flex items-center justify-center gap-3 rounded-lg bg-muted/50 px-6 py-3 self-center'>
-            <span className='text-sm font-semibold'>You won a:</span>
-            <div className='flex h-10 w-10 items-center justify-center rounded bg-muted text-xl'>{raid.reward}</div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          )}
+        />
+      }
+      right={
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              Monster lost — <span className='text-emerald-500'>you win!</span>
+            </CardTitle>
+            <CardDescription className='text-2xl font-bold italic'>Argh!</CardDescription>
+          </CardHeader>
+          <CardContent className='flex flex-col gap-4'>
+            <BossStage monster={defeatedMonster} members={raid.members} dim />
+            {raid.reward && (
+              <div className='flex items-center justify-center gap-3 self-center rounded-lg bg-muted/50 px-6 py-3'>
+                <span className='text-sm font-semibold'>You won a:</span>
+                <div className='flex size-10 items-center justify-center rounded bg-muted text-xl'>{raid.reward}</div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      }
+    />
   )
 }
 


### PR DESCRIPTION
improved design for the Boss Raid and Character pages to improve consistencies and readability.

Brought the boss more into focus and centralize it
Displayed the actual character images instead of names
Make the characters placed intelligently in a U-shape and face the boss
Characters now contain their life more closely and not in a separate section
Improved the boss raid task timer to be a progress bar
closes #80
relates to #77 