### PR TITLE
feat: frontend achievements in character and group member. closes #23. closes #10. 

### DIFF
--- a/app/app/character/index.tsx
+++ b/app/app/character/index.tsx
@@ -4,9 +4,41 @@ import { CharacterStats } from '@/components/stats'
 import { Card, CardContent } from '@/components/ui/card'
 import { useApi } from '@/hooks/useApi'
 import { useAuth } from '@/hooks/useAuth'
-import { Axe, Book, Flame, HatGlasses, Heart, Shirt, Star, Sword, User } from 'lucide-react'
+import {
+  CheckCircle,
+  Dumbbell,
+  HatGlasses,
+  Heart,
+  Lightbulb,
+  LucideIcon,
+  Shield,
+  Shirt,
+  Star,
+  Sword,
+  TrendingUp,
+  Trophy,
+  User,
+} from 'lucide-react'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
+
+const achievementConfig: Record<string, { icon: LucideIcon; color: string }> = {
+  FIRST_HABIT: { icon: CheckCircle, color: 'text-emerald-500' },
+  STREAK_3: { icon: TrendingUp, color: 'text-orange-400' },
+  STREAK_7: { icon: Trophy, color: 'text-yellow-500' },
+  STRENGTH_25: { icon: Dumbbell, color: 'text-rose-500' },
+  INTELLIGENCE_25: { icon: Lightbulb, color: 'text-sky-400' },
+  RESILIENCE_25: { icon: Shield, color: 'text-violet-500' },
+}
+
+type AchievementData = {
+  id: number
+  key: string
+  name: string
+  description: string
+  icon: string
+  earnedAt: string
+}
 
 type CharacterData = {
   id: number
@@ -29,17 +61,22 @@ export default function CharacterPage() {
   const api = useApi()
 
   const [character, setCharacter] = useState<CharacterData | null>(null)
+  const [achievements, setAchievements] = useState<AchievementData[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!user) return
 
-    const fetchCharacter = async () => {
+    const fetchAll = async () => {
       try {
         setIsLoading(true)
-        const data = await api.get<CharacterData>(`/users/${user.id}/character`)
-        setCharacter(data)
+        const [characterData, achievementsData] = await Promise.all([
+          api.get<CharacterData>(`/users/${user.id}/character`),
+          api.get<AchievementData[]>(`/users/${user.id}/achievements`),
+        ])
+        setCharacter(characterData)
+        setAchievements(achievementsData)
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to load character')
       } finally {
@@ -47,7 +84,7 @@ export default function CharacterPage() {
       }
     }
 
-    void fetchCharacter()
+    void fetchAll()
   }, [user])
 
   if (!user) return null
@@ -174,15 +211,25 @@ export default function CharacterPage() {
       </div>
 
       <h3>Achievements</h3>
-      <div className='grid gap-4 md:grid-cols-3'>
-        {[Axe, Flame, Book].map((Icon, i) => (
-          <Card key={i}>
-            <CardContent className='flex aspect-square items-center justify-center'>
-              <Icon className='size-20 text-muted-foreground/40' />
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      {achievements.length === 0 ? (
+        <p className='text-muted-foreground'>No achievements earned yet.</p>
+      ) : (
+        <div className='grid gap-4 md:grid-cols-3'>
+          {achievements.map((a) => {
+            const { icon: Icon, color } = achievementConfig[a.key] ?? { icon: Trophy, color: 'text-muted-foreground' }
+            return (
+              <Card key={a.id}>
+                <CardContent className='flex flex-col items-center justify-center gap-2 p-6 text-center'>
+                  <Icon className={`size-12 ${color}`} />
+                  <p className='font-bold'>{a.name}</p>
+                  <p className='text-sm text-muted-foreground'>{a.description}</p>
+                  <p className='text-xs text-muted-foreground/60'>Earned {new Date(a.earnedAt).toLocaleDateString()}</p>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
     </main>
   )
 }

--- a/app/app/groups/index.tsx
+++ b/app/app/groups/index.tsx
@@ -5,10 +5,23 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { useApi } from '@/hooks/useApi'
 import { useAuth } from '@/hooks/useAuth'
 import { useLiveOnlineUsers } from '@/hooks/useLiveOnlineUsers'
 import { User } from '@/types/user'
+import { CheckCircle, Dumbbell, Lightbulb, LucideIcon, Shield, TrendingUp, Trophy } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+
+const achievementConfig: Record<string, { icon: LucideIcon; color: string }> = {
+  FIRST_HABIT: { icon: CheckCircle, color: 'text-emerald-500' },
+  STREAK_3: { icon: TrendingUp, color: 'text-orange-400' },
+  STREAK_7: { icon: Trophy, color: 'text-yellow-500' },
+  STRENGTH_25: { icon: Dumbbell, color: 'text-rose-500' },
+  INTELLIGENCE_25: { icon: Lightbulb, color: 'text-sky-400' },
+  RESILIENCE_25: { icon: Shield, color: 'text-violet-500' },
+}
+
+type Achievement = { id: number; key: string; name: string; description: string }
 
 interface GroupMember extends User {
   level?: number | null
@@ -29,7 +42,9 @@ interface Group {
 export default function GroupsPage() {
   const auth = useAuth()
   const user = auth.user
+  const api = useApi()
   const { users: onlineUsers } = useLiveOnlineUsers()
+  const [memberAchievements, setMemberAchievements] = useState<Achievement[]>([])
 
   const [groups, setGroups] = useState<Group[]>([])
   const [loading, setLoading] = useState(true)
@@ -50,9 +65,15 @@ export default function GroupsPage() {
 
   const getMemberLevel = (member: GroupMember) => member.level ?? member.character?.level ?? null
 
-  const handleOpenProfile = (member: GroupMember) => {
+  const handleOpenProfile = async (member: GroupMember) => {
     setSelectedMember(member)
     setIsProfileOpen(true)
+    try {
+      const data = await api.get<Achievement[]>(`/users/${member.id}/achievements`)
+      setMemberAchievements(data)
+    } catch {
+      setMemberAchievements([])
+    }
   }
 
   const [groupName, setGroupName] = useState('')
@@ -260,6 +281,7 @@ export default function GroupsPage() {
           setIsProfileOpen(open)
           if (!open) {
             setSelectedMember(null)
+            setMemberAchievements([])
           }
         }}
       >
@@ -293,12 +315,28 @@ export default function GroupsPage() {
 
               <Card>
                 <CardContent className='flex flex-col gap-3'>
-                  <p className='text-xs uppercase text-muted-foreground'>Achievement badges</p>
-                  <div className='flex flex-wrap gap-2'>
-                    <Badge variant='outline'>Badge 1</Badge> {/* TODO: Implement Badges here */}
-                    <Badge variant='outline'>Badge 2</Badge>
-                    <Badge variant='outline'>Badge 3</Badge>
-                  </div>
+                  <p className='text-xs uppercase text-muted-foreground'>Achievements</p>
+                  {memberAchievements.length === 0 ? (
+                    <p className='text-sm text-muted-foreground'>No achievements yet.</p>
+                  ) : (
+                    <div className='flex flex-col gap-2'>
+                      {memberAchievements.map((a) => {
+                        const { icon: Icon, color } = achievementConfig[a.key] ?? {
+                          icon: Trophy,
+                          color: 'text-muted-foreground',
+                        }
+                        return (
+                          <div key={a.id} className='flex items-center gap-3'>
+                            <Icon className={`size-5 shrink-0 ${color}`} />
+                            <div>
+                              <p className='text-sm font-medium'>{a.name}</p>
+                              <p className='text-xs text-muted-foreground'>{a.description}</p>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
                 </CardContent>
               </Card>
 

--- a/app/app/habits/index.tsx
+++ b/app/app/habits/index.tsx
@@ -18,7 +18,7 @@ function weightLabel(w: number) {
   return w === 1 ? 'Easy' : w === 2 ? 'Medium' : 'Hard'
 }
 
-// ─── main page ────────────────────────────────────────────────────────────────
+// ============================== main page ==============================
 
 export default function HabitsPage() {
   const { user } = useAuth()
@@ -45,11 +45,12 @@ export default function HabitsPage() {
   )
 }
 
-// ─── habits ───────────────────────────────────────────────────────────
+// ============================== habits ==============================
 
 function HabitsSection({ userId }: { userId: string | number }) {
   const api = useApi()
   const [habits, setHabits] = useState<Habit[]>([])
+  const [weatherCode, setWeatherCode] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -65,6 +66,7 @@ function HabitsSection({ userId }: { userId: string | number }) {
 
   useEffect(() => {
     void fetchHabits()
+    void fetchWeather()
   }, [userId])
 
   async function fetchHabits() {
@@ -76,6 +78,15 @@ function HabitsSection({ userId }: { userId: string | number }) {
       setError(e instanceof Error ? e.message : 'Failed to load habits')
     } finally {
       setIsLoading(false)
+    }
+  }
+
+  async function fetchWeather() {
+    try {
+      const code = await api.get<number>('/weather')
+      setWeatherCode(code)
+    } catch {
+      // just for safety (if weather API fails) -> no bonus
     }
   }
 
@@ -140,6 +151,7 @@ function HabitsSection({ userId }: { userId: string | number }) {
             <HabitCard
               key={habit.id}
               habit={habit}
+              weatherCode={weatherCode}
               onComplete={() => void completeHabit(habit.id)}
               onDelete={() => void deleteHabit(habit.id)}
             />
@@ -150,7 +162,7 @@ function HabitsSection({ userId }: { userId: string | number }) {
   )
 }
 
-// ─── todos ────────────────────────────────────────────────────────────
+// ============================== todos ==============================
 
 function TodosSection({ userId }: { userId: string | number }) {
   const api = useApi()
@@ -257,7 +269,7 @@ function TodosSection({ userId }: { userId: string | number }) {
   )
 }
 
-// ─── form components ──────────────────────────────────────────────────────────
+// ============================== form components ==============================
 // extracted so dialog content stays readable
 
 function HabitForm({ value, onChange, onSubmit }: { value: NewHabit; onChange: (v: NewHabit) => void; onSubmit: () => void }) {

--- a/components/habit-card.tsx
+++ b/components/habit-card.tsx
@@ -6,8 +6,34 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { type Habit, categoryLabel, weightLabel } from '@/types/task'
 import { Brain, Check, Flame, Heart, Trash2 } from 'lucide-react'
 
+function getMultiplier(weatherCode: number, category: Habit['category']): number {
+  if (category === 'PHYSICAL') {
+    if (weatherCode <= 3) return 1.0
+    else if (weatherCode <= 48) return 1.2
+    else if (weatherCode <= 67) return 1.5
+    else if (weatherCode <= 77) return 1.8
+    else return 2.0
+  } 
+  else if (category === 'COGNITIVE') {
+    if (weatherCode <= 3) return 1.8
+    else if (weatherCode <= 48) return 1.6
+    else if (weatherCode <= 67) return 1.4
+    else if (weatherCode <= 77) return 1.2
+    else return 1.0
+  } 
+  else if (category === 'EMOTIONAL') {
+    if (weatherCode <= 3) return 1.0
+    else if (weatherCode <= 48) return 1.2
+    else if (weatherCode <= 67) return 1.6
+    else if (weatherCode <= 77) return 1.8
+    else return 1.0
+  }
+  return 1.0
+}
+
 interface HabitCardProps {
   habit: Habit
+  weatherCode: number
   onComplete: () => void
   onDelete: () => void
 }
@@ -23,7 +49,8 @@ function CategoryIcon({ category }: { category: Habit['category'] }) {
   }
 }
 
-export function HabitCard({ habit, onComplete, onDelete }: HabitCardProps) {
+export function HabitCard({ habit, weatherCode, onComplete, onDelete }: HabitCardProps) {
+  const multiplier = getMultiplier(weatherCode, habit.category)
   return (
     <Card className={habit.completed ? 'opacity-60' : ''}>
       <CardHeader>
@@ -48,7 +75,7 @@ export function HabitCard({ habit, onComplete, onDelete }: HabitCardProps) {
             </div>
 
             <p className='text-xs text-muted-foreground'>
-              Completes for {habit.weight * 10} base XP — weather multiplier applies.
+              Completes for {habit.weight * 10} base XP{multiplier > 1.0 ? ` -> ${multiplier}x XP weather multiplier` : ''}
             </p>
 
             {habit.dueAt && !habit.completed && (

--- a/components/weather-icon.tsx
+++ b/components/weather-icon.tsx
@@ -8,6 +8,12 @@ type WeatherIconProps = {
   size?: number
 }
 
+function getBoostedCategories(code: number): string {
+  if (code <= 3) return 'Cognitive habits boosted'
+  if (code <= 77) return 'Physical, Cognitive & Emotional habits boosted'
+  return 'Physical habits boosted'
+}
+
 export function WeatherIcon({ weatherCode, size = 36 }: WeatherIconProps) {
   if (weatherCode === null) return null
 
@@ -24,7 +30,10 @@ export function WeatherIcon({ weatherCode, size = 36 }: WeatherIconProps) {
     <Card className='w-fit h-fit'>
       <CardContent className='flex items-center gap-2 p-2 px-4'>
         {icon}
-        <CardTitle className='text-lg'>It&apos;s {label} today.</CardTitle>
+        <div>
+          <CardTitle className='text-lg'>It&apos;s {label} today.</CardTitle>
+          <p className='text-xs text-muted-foreground'>{getBoostedCategories(weatherCode)}</p>
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
- character page now fetches and shows earned achievements with icons, names, descriptions and earned date -> closes #23 
- when clicking on another user profile in the group member section, then you can now see the earned achievements of the selected user -> closes #10 
- some minor adjustments: habit cards now show the actual weather XP multiplier for their corresponding category, it is fetched from backend weather code. further the weather widget now shows which habit categories are currently boosted