### PR TITLE
moved away from basepath for backend calls

### DIFF
--- a/providers/websocket-provider.tsx
+++ b/providers/websocket-provider.tsx
@@ -91,7 +91,7 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
     const connect = () => {
       if (ignore) return
 
-      const socketUrl = new URL('/api/ws/presence', getWebSocketDomain()).toString()
+      const socketUrl = new URL('/ws/presence', getWebSocketDomain()).toString()
       socket = new WebSocket(socketUrl)
 
       socket.onopen = () => {
@@ -142,7 +142,7 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
     const connect = () => {
       if (ignore) return
 
-      const socketUrl = new URL('/api/ws/raid', getWebSocketDomain()).toString()
+      const socketUrl = new URL('/ws/raid', getWebSocketDomain()).toString()
       socket = new WebSocket(socketUrl)
 
       socket.onopen = () => {
@@ -194,7 +194,7 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
     const connect = () => {
       if (ignore) return
 
-      const socketUrl = new URL('/api/ws/character', getWebSocketDomain()).toString()
+      const socketUrl = new URL('/ws/character', getWebSocketDomain()).toString()
       socket = new WebSocket(socketUrl)
 
       socket.onopen = () => {

--- a/utils/domain.ts
+++ b/utils/domain.ts
@@ -3,7 +3,7 @@ import { isProduction } from "./environment";
 /**
  * Returns the API base URL based on the current environment.
  * In production it retrieves the URL from NEXT_PUBLIC_PROD_API_URL (or falls back to a hardcoded url).
- * In development, it returns "http://localhost:8080/api".
+ * In development, it returns "http://localhost:8080".
  */
 export function getApiDomain(): string {
   const prodUrl = process.env.NEXT_PUBLIC_PROD_API_URL ||
@@ -13,7 +13,7 @@ export function getApiDomain(): string {
 }
 
 export function buildApiUrl(endpoint: string): string {
-  return `${getApiDomain()}/api${endpoint}`;
+  return `${getApiDomain()}${endpoint}`;
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue with inconsistent basePath urls `/api`  #100 
The issue occurred (rather suddenly) on production with the following errors:

```sh
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/raid' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/presence' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/character' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/raid' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/presence' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/character' failed:
```

which clearly shows no basePath being applied. However, the basePath was set in the fetch.

closes #100
ref  joshuademarco/sopra-fs26-group-08-server#130