### PR TITLE
feat: reflect penalty visually on UI and bugfix weather multiplier frontend part. closes #7 #90

### DIFF
--- a/app/app/habits/index.tsx
+++ b/app/app/habits/index.tsx
@@ -30,7 +30,7 @@ export default function HabitsPage() {
   return (
     <main className='flex flex-1 flex-col gap-4 p-4 pt-0'>
       <div className='flex items-center gap-2'>
-        <h1 className='text-3xl font-bold tracking-tight'>Tasks</h1>
+        <h2>Tasks</h2>
         <Tooltip>
           <TooltipTrigger asChild>
             <Info className='h-5 w-5 text-muted-foreground' />
@@ -38,7 +38,7 @@ export default function HabitsPage() {
           <TooltipContent className='max-w-sm'>
             <strong>Habits:</strong> Recurring actions you do daily, weekly, or monthly. Keep an eye on the sky! Specific habit
             categories get a weather-based XP boost to keep you motivated. <strong>ToDos:</strong> One-time tasks. While these
-            don't receive weather bonuses, completing them still earns you base XP and levels up your character's stats in that
+            don&apos;t receive weather bonuses, completing them still earns you base XP and levels up your character&apos;s stats in that
             category.
           </TooltipContent>
         </Tooltip>
@@ -313,8 +313,8 @@ function HabitForm({ value, onChange, onSubmit }: { value: NewHabit; onChange: (
               <Info className='h-3.5 w-3.5 text-muted-foreground' />
             </TooltipTrigger>
             <TooltipContent>
-              Choose the category that best fits your habit. Completing it levels the matching character stat ("Morning Run"
-              could be an example for a Physical habit, hence completing it would level up your character's Strength). Weather
+              Choose the category that best fits your habit. Completing it levels the matching character stat (&quot;Morning Run&quot;
+              could be an example for a Physical habit, hence completing it would level up your character&apos;s Strength). Weather
               conditions can boost XP for specific categories.
             </TooltipContent>
           </Tooltip>
@@ -459,8 +459,8 @@ function TodoForm({ value, onChange, onSubmit }: { value: NewTodo; onChange: (v:
               <Info className='h-3.5 w-3.5 text-muted-foreground' />
             </TooltipTrigger>
             <TooltipContent>
-              Choose the category that best fits your To-Do. Completing it levels the matching character stat. ("Mow the lawn"
-              could be an example for a Physical To-Do, hence completing it would level up your character's Strength)
+              Choose the category that best fits your To-Do. Completing it levels the matching character stat. (&quot;Mow the lawn&quot;
+              could be an example for a Physical To-Do, hence completing it would level up your character&apos;s Strength)
             </TooltipContent>
           </Tooltip>
         </Label>

--- a/app/app/habits/index.tsx
+++ b/app/app/habits/index.tsx
@@ -8,10 +8,11 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useApi } from '@/hooks/useApi'
 import { useAuth } from '@/hooks/useAuth'
 import type { Habit, HabitCategory, HabitFrequency, NewHabit, NewTodo, Todo } from '@/types/task'
-import { Brain, Flame, Heart, Minus, Plus } from 'lucide-react'
+import { AlertTriangle, Brain, Flame, Heart, Info, Minus, Plus } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 function weightLabel(w: number) {
@@ -28,7 +29,20 @@ export default function HabitsPage() {
 
   return (
     <main className='flex flex-1 flex-col gap-4 p-4 pt-0'>
-      <h1 className='text-3xl font-bold tracking-tight'>Tasks</h1>
+      <div className='flex items-center gap-2'>
+        <h1 className='text-3xl font-bold tracking-tight'>Tasks</h1>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Info className='h-5 w-5 text-muted-foreground' />
+          </TooltipTrigger>
+          <TooltipContent className='max-w-sm'>
+            <strong>Habits:</strong> Recurring actions you do daily, weekly, or monthly. Keep an eye on the sky! Specific habit
+            categories get a weather-based XP boost to keep you motivated. <strong>ToDos:</strong> One-time tasks. While these
+            don't receive weather bonuses, completing them still earns you base XP and levels up your character's stats in that
+            category.
+          </TooltipContent>
+        </Tooltip>
+      </div>
 
       <div className='flex gap-2'>
         <Button variant={activeTab === 'habits' ? 'default' : 'outline'} onClick={() => setActiveTab('habits')}>
@@ -50,7 +64,6 @@ export default function HabitsPage() {
 function HabitsSection({ userId }: { userId: string | number }) {
   const api = useApi()
   const [habits, setHabits] = useState<Habit[]>([])
-  const [weatherCode, setWeatherCode] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -66,7 +79,6 @@ function HabitsSection({ userId }: { userId: string | number }) {
 
   useEffect(() => {
     void fetchHabits()
-    void fetchWeather()
   }, [userId])
 
   async function fetchHabits() {
@@ -78,15 +90,6 @@ function HabitsSection({ userId }: { userId: string | number }) {
       setError(e instanceof Error ? e.message : 'Failed to load habits')
     } finally {
       setIsLoading(false)
-    }
-  }
-
-  async function fetchWeather() {
-    try {
-      const code = await api.get<number>('/weather')
-      setWeatherCode(code)
-    } catch {
-      // just for safety (if weather API fails) -> no bonus
     }
   }
 
@@ -147,11 +150,16 @@ function HabitsSection({ userId }: { userId: string | number }) {
         <EmptyState message='No habits yet. Add one to start earning XP!' />
       ) : (
         <div className='flex flex-col gap-3'>
+          {habits.some((h) => h.penaltyApplied) && (
+            <div className='flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive'>
+              <AlertTriangle className='h-4 w-4 shrink-0' />
+              <span>You missed habits last period - your character lost health.</span>
+            </div>
+          )}
           {habits.map((habit) => (
             <HabitCard
               key={habit.id}
               habit={habit}
-              weatherCode={weatherCode}
               onComplete={() => void completeHabit(habit.id)}
               onDelete={() => void deleteHabit(habit.id)}
             />
@@ -298,7 +306,19 @@ function HabitForm({ value, onChange, onSubmit }: { value: NewHabit; onChange: (
 
       {/* habit category for character stats */}
       <div className='flex flex-col gap-1.5'>
-        <Label>Category</Label>
+        <Label>
+          Category
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className='h-3.5 w-3.5 text-muted-foreground' />
+            </TooltipTrigger>
+            <TooltipContent>
+              Choose the category that best fits your habit. Completing it levels the matching character stat ("Morning Run"
+              could be an example for a Physical habit, hence completing it would level up your character's Strength). Weather
+              conditions can boost XP for specific categories.
+            </TooltipContent>
+          </Tooltip>
+        </Label>
         <Select value={value.category} onValueChange={(v) => onChange({ ...value, category: v as HabitCategory })}>
           <SelectTrigger>
             <SelectValue />
@@ -339,7 +359,18 @@ function HabitForm({ value, onChange, onSubmit }: { value: NewHabit; onChange: (
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label>Type</Label>
+        <Label>
+          Type
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className='h-3.5 w-3.5 text-muted-foreground' />
+            </TooltipTrigger>
+            <TooltipContent>
+              Positive habits (e.g. Morning run) reward you with XP when completed. Negative habits (e.g. Smoking) represent bad
+              habits you want to avoid - completing them applies a health reduction to your character.
+            </TooltipContent>
+          </Tooltip>
+        </Label>
         <div className='flex gap-2'>
           <Button
             type='button'
@@ -361,7 +392,18 @@ function HabitForm({ value, onChange, onSubmit }: { value: NewHabit; onChange: (
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label>Difficulty</Label>
+        <Label>
+          Difficulty
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className='h-3.5 w-3.5 text-muted-foreground' />
+            </TooltipTrigger>
+            <TooltipContent>
+              Difficulty describes how challenging this habit is to complete. Higher difficulty means greater XP rewards when
+              completed, but also greater health damage when missed or a negative habit is completed.
+            </TooltipContent>
+          </Tooltip>
+        </Label>
         <div className='flex gap-2'>
           {[1, 2, 3].map((w) => (
             <Button
@@ -410,7 +452,18 @@ function TodoForm({ value, onChange, onSubmit }: { value: NewTodo; onChange: (v:
 
       {/* todo category for character stats */}
       <div className='flex flex-col gap-1.5'>
-        <Label>Category</Label>
+        <Label>
+          Category
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className='h-3.5 w-3.5 text-muted-foreground' />
+            </TooltipTrigger>
+            <TooltipContent>
+              Choose the category that best fits your To-Do. Completing it levels the matching character stat. ("Mow the lawn"
+              could be an example for a Physical To-Do, hence completing it would level up your character's Strength)
+            </TooltipContent>
+          </Tooltip>
+        </Label>
         <Select value={value.category} onValueChange={(v) => onChange({ ...value, category: v as HabitCategory })}>
           <SelectTrigger>
             <SelectValue />
@@ -436,7 +489,18 @@ function TodoForm({ value, onChange, onSubmit }: { value: NewTodo; onChange: (v:
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label>Difficulty</Label>
+        <Label>
+          Difficulty
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className='h-3.5 w-3.5 text-muted-foreground' />
+            </TooltipTrigger>
+            <TooltipContent>
+              Difficulty describes how challenging this To-Do is to complete. Higher difficulty means greater XP rewards when
+              completed.
+            </TooltipContent>
+          </Tooltip>
+        </Label>
         <div className='flex gap-2'>
           {[1, 2, 3].map((w) => (
             <Button

--- a/components/habit-card.tsx
+++ b/components/habit-card.tsx
@@ -4,36 +4,10 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { type Habit, categoryLabel, weightLabel } from '@/types/task'
-import { Brain, Check, Flame, Heart, Trash2 } from 'lucide-react'
-
-function getMultiplier(weatherCode: number, category: Habit['category']): number {
-  if (category === 'PHYSICAL') {
-    if (weatherCode <= 3) return 1.0
-    else if (weatherCode <= 48) return 1.2
-    else if (weatherCode <= 67) return 1.5
-    else if (weatherCode <= 77) return 1.8
-    else return 2.0
-  } 
-  else if (category === 'COGNITIVE') {
-    if (weatherCode <= 3) return 1.8
-    else if (weatherCode <= 48) return 1.6
-    else if (weatherCode <= 67) return 1.4
-    else if (weatherCode <= 77) return 1.2
-    else return 1.0
-  } 
-  else if (category === 'EMOTIONAL') {
-    if (weatherCode <= 3) return 1.0
-    else if (weatherCode <= 48) return 1.2
-    else if (weatherCode <= 67) return 1.6
-    else if (weatherCode <= 77) return 1.8
-    else return 1.0
-  }
-  return 1.0
-}
+import { AlertTriangle, Brain, Check, Flame, Heart, Trash2 } from 'lucide-react'
 
 interface HabitCardProps {
   habit: Habit
-  weatherCode: number
   onComplete: () => void
   onDelete: () => void
 }
@@ -49,8 +23,8 @@ function CategoryIcon({ category }: { category: Habit['category'] }) {
   }
 }
 
-export function HabitCard({ habit, weatherCode, onComplete, onDelete }: HabitCardProps) {
-  const multiplier = getMultiplier(weatherCode, habit.category)
+export function HabitCard({ habit, onComplete, onDelete }: HabitCardProps) {
+  const multiplier = habit.multiplier ?? 1
   return (
     <Card className={habit.completed ? 'opacity-60' : ''}>
       <CardHeader>
@@ -63,6 +37,13 @@ export function HabitCard({ habit, weatherCode, onComplete, onDelete }: HabitCar
         </div>
 
         {habit.description && <CardDescription>{habit.description}</CardDescription>}
+
+        {habit.penaltyApplied && (
+          <div className='flex items-center gap-1.5 text-sm text-destructive'>
+            <AlertTriangle className='h-4 w-4 shrink-0' />
+            <span>Missed last period - your character lost health.</span>
+          </div>
+        )}
       </CardHeader>
 
       <CardContent>
@@ -74,9 +55,16 @@ export function HabitCard({ habit, weatherCode, onComplete, onDelete }: HabitCar
               <Badge variant='secondary'>{habit.frequency.charAt(0) + habit.frequency.slice(1).toLowerCase()}</Badge>
             </div>
 
-            <p className='text-xs text-muted-foreground'>
-              Completes for {habit.weight * 10} base XP{multiplier > 1.0 ? ` -> ${multiplier}x XP weather multiplier` : ''}
-            </p>
+            {habit.positive ? (
+              <p className='text-xs text-muted-foreground'>
+                Completes for {habit.weight * 10} base XP
+                {multiplier > 1.0 && <span className='text-yellow-500'>{` -> ${multiplier}x XP weather multiplier`}</span>}
+              </p>
+            ) : (
+              <p className='text-xs text-destructive'>
+                Completing this negative habit reduces your character&apos;s health by {habit.weight} HP
+              </p>
+            )}
 
             {habit.dueAt && !habit.completed && (
               <p className='text-xs text-muted-foreground'>Due: {new Date(habit.dueAt).toLocaleDateString()}</p>
@@ -93,10 +81,12 @@ export function HabitCard({ habit, weatherCode, onComplete, onDelete }: HabitCar
             </div>
           </div>
 
-          <div className='flex flex-col items-center gap-1 rounded-lg bg-muted/40 p-3'>
-            <span className='text-xs text-muted-foreground'>Streak</span>
-            <span className='text-2xl font-bold'>{habit.streak}</span>
-          </div>
+          {habit.positive && (
+            <div className='flex flex-col items-center gap-1 rounded-lg bg-muted/40 p-3'>
+              <span className='text-xs text-muted-foreground'>Streak</span>
+              <span className='text-2xl font-bold'>{habit.streak}</span>
+            </div>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/components/todo-card.tsx
+++ b/components/todo-card.tsx
@@ -70,9 +70,7 @@ export function TodoCard({ todo, onComplete, onDelete }: TodoCardProps) {
               <Badge variant='secondary'>{weightLabel(todo.weight)}</Badge>
             </div>
 
-            <p className='text-xs text-muted-foreground'>
-              Completes for {todo.weight * 10} XP — one-time, no weather multiplier.
-            </p>
+            <p className='text-xs text-muted-foreground'>Completes for {todo.weight * 10} XP</p>
 
             <div className='flex items-center gap-2'>
               <Button size='icon-lg' onClick={onComplete} disabled={todo.completed}>

--- a/types/task.ts
+++ b/types/task.ts
@@ -14,6 +14,8 @@ export type Habit = {
   dueAt?: string
   completedAt?: string
   createdAt: string
+  multiplier?: number
+  penaltyApplied: boolean
 }
 
 export type Todo = {


### PR DESCRIPTION
implemented visual feedback for penalty system, refactoring weather multiplier and added many tooltips based on beta testing feedback.
- user now gets a visual feedback in habits section that they missed the due date for a habit and they got a penalty (HP deduction based on difficulty of habit). -> closes #7 
- removed client side weather fetch and multiplier calculation as backend now takes care of this (only source of truth) by new multiplier and penaltyApplied entries. -> closes #90 
- added new tooltips for habits and todos as this was highlighted in beta testing. now tasks, habits, todos, categories, difficulties etc. have an i symbol next to it so the user can hover and get all the needed information to understand what's going on and what to do.
- enhanced user experience by adjusting e.g. text for weather multiplier, hiding streak for negative habits etc. 