### PR TITLE
feat: skip task button, character death state, responsive layouts, form error toasts and minor fixes

### DIFF
--- a/app/app/boss-raid/index.tsx
+++ b/app/app/boss-raid/index.tsx
@@ -275,6 +275,15 @@ export default function BossRaidPage() {
     }
   }
 
+  const handleSkipTask = async (raidId: number, task: RaidTaskData, groupId: number) => {
+    try {
+      await api.post(`/raids/${raidId}/tasks/${task.id}/skip`, {})
+      await refreshRaids(groupId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not skip task')
+    }
+  }
+
   if (!currentUser) {
     return <div className='flex items-center justify-center p-8 text-muted-foreground'>Loading…</div>
   }
@@ -349,6 +358,7 @@ export default function BossRaidPage() {
           onJoin={() => handleJoin(liveRaid.id, liveRaid.groupId)}
           onRsvp={(accepted) => handleRsvp(liveRaid.id, liveRaid.groupId, accepted)}
           onCompleteTask={(task, success) => handleCompleteTask(liveRaid.id, task, success, liveRaid.groupId)}
+          onSkipTask={(task) => handleSkipTask(liveRaid.id, task, liveRaid.groupId)}
         />
       ) : (
         (() => {

--- a/app/app/boss-raid/raid-view.tsx
+++ b/app/app/boss-raid/raid-view.tsx
@@ -18,6 +18,7 @@ function TasksPanel({
   totalAssigned,
   startedAt,
   onCompleteTask,
+  onSkipTask
 }: {
   activeTask: RaidTaskData | null
   upcomingTasks: RaidTaskData[]
@@ -25,6 +26,7 @@ function TasksPanel({
   totalAssigned: number
   startedAt: string | null
   onCompleteTask: (task: RaidTaskData, success: boolean) => void
+  onSkipTask: (task: RaidTaskData) => void
 }) {
   return (
     <Card className='self-start'>
@@ -40,6 +42,7 @@ function TasksPanel({
             task={activeTask}
             startedAt={startedAt}
             onSuccess={() => onCompleteTask(activeTask, true)}
+            onSkip={() => onSkipTask(activeTask)}
           />
         )}
 
@@ -90,6 +93,7 @@ export function RaidView({
   onJoin,
   onRsvp,
   onCompleteTask,
+  onSkipTask
 }: {
   raid: RaidData
   currentUserId: number | string
@@ -97,6 +101,7 @@ export function RaidView({
   onJoin: () => void
   onRsvp: (accepted: boolean) => void
   onCompleteTask: (task: RaidTaskData, success: boolean) => void
+  onSkipTask: (task: RaidTaskData) => void
 }) {
   const uid = Number(currentUserId)
   const cardData = toRaidCard(raid, currentUserId, onlineUserIds)
@@ -166,6 +171,7 @@ export function RaidView({
           totalAssigned={allMyTasks.length}
           startedAt={raid.startedAt}
           onCompleteTask={onCompleteTask}
+          onSkipTask={onSkipTask}
         />
       )
     } else {

--- a/app/app/boss-raid/task-card.tsx
+++ b/app/app/boss-raid/task-card.tsx
@@ -4,17 +4,19 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
 import { RaidTaskData } from '@/types/raids'
-import { Check } from 'lucide-react'
+import { Check, SkipForward } from 'lucide-react'
 import { taskWindowSecondsLeft } from './utils'
 
 export function TaskCard({
   task,
   startedAt,
   onSuccess,
+  onSkip,
 }: {
   task: RaidTaskData
   startedAt: string | null
   onSuccess: () => void
+  onSkip: () => void
 }) {
   const secsLeft = Math.max(0, taskWindowSecondsLeft(task, startedAt))
   const hasTimer = task.timeLimitSeconds != null && task.timeLimitSeconds > 0
@@ -33,10 +35,22 @@ export function TaskCard({
               {(task.groupDamage ?? 0) > 0 && <span className='text-destructive'>{task.groupDamage} group damage</span>}
             </div>
           </div>
-          <Button size='sm' onClick={onSuccess} title='Mark as done' className='self-center'>
-            <Check />
-            Done
-          </Button>
+          <div className='flex flex-col gap-2 self-center'>
+            <Button size='sm' onClick={onSuccess} title='Mark as done'>
+              <Check />
+              Done
+            </Button>
+            <Button
+              size='sm'
+              variant='ghost'
+              onClick={onSkip}
+              title={`Skip this task — group damage (${task.groupDamage ?? 0}) still applies to your team`}
+              className='text-muted-foreground'
+            >
+              <SkipForward />
+              Skip
+            </Button>
+          </div>
         </div>
         {hasTimer && <Progress value={percentLeft} innerClassName={isLow ? 'bg-destructive' : 'bg-primary'} />}
       </CardContent>

--- a/app/app/character/index.tsx
+++ b/app/app/character/index.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { useApi } from '@/hooks/useApi'
 import { useAuth } from '@/hooks/useAuth'
+import { useWebsocketContext } from '@/hooks/useWebsocketContext'
 import {
   CheckCircle,
   Dumbbell,
@@ -20,6 +21,7 @@ import {
   Trophy,
   User,
 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -68,12 +70,14 @@ type InventoryItem = {
 export default function CharacterPage() {
   const { user } = useAuth()
   const api = useApi()
+  const { subscribeToCharacterUpdates } = useWebsocketContext()
 
   const [character, setCharacter] = useState<CharacterData | null>(null)
   const [achievements, setAchievements] = useState<AchievementData[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [inventory, setInventory] = useState<InventoryItem[]>([])
   const [pickerSlot, setPickerSlot] = useState<'HAT' | 'CHESTPIECE' | 'HANDHELD' | null>(null)
+  const [reviving, setReviving] = useState(false)
 
   useEffect(() => {
     if (!user) return
@@ -98,6 +102,38 @@ export default function CharacterPage() {
 
     void fetchAll()
   }, [user, api])
+
+  useEffect(() => {
+    return subscribeToCharacterUpdates((msg) => {
+      setCharacter((prev) =>
+        prev
+          ? {
+              ...prev,
+              level: msg.level,
+              health: msg.health,
+              maxHealth: msg.maxHealth,
+              experience: msg.experience,
+              strength: msg.strength,
+              intelligence: msg.intelligence,
+              resilience: msg.resilience,
+            }
+          : prev,
+      )
+    })
+  }, [subscribeToCharacterUpdates])
+
+  async function handleRevive() {
+    if (!user) return
+    setReviving(true)
+    try {
+      const data = await api.post<CharacterData>(`/users/${user.id}/character/revive`, {})
+      setCharacter(data)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to revive character')
+    } finally {
+      setReviving(false)
+    }
+  }
 
   async function equipItem(itemId: number) {
     if (!character) return
@@ -138,6 +174,7 @@ export default function CharacterPage() {
   }
 
   const xpThreshold = character.level * 100
+  const isKnockedOut = character.health <= 0
 
   const slotLabels: Record<string, string> = {
     HAT: 'hats',
@@ -155,17 +192,24 @@ export default function CharacterPage() {
     <main className='flex flex-1 flex-col gap-4'>
       <Card>
         <CardContent className='flex flex-col gap-6 md:flex-row md:items-center'>
-          <div className='flex aspect-square w-full items-center justify-center rounded-lg bg-muted/20 md:w-48'>
-            {character.type ? (
-              <Image
-                src={`/characters/${character.type}/rotations/south.png`}
-                alt={character.type}
-                width={192}
-                height={192}
-                style={{ imageRendering: 'pixelated' }}
-              />
-            ) : (
-              <User className='size-20' />
+          <div className='flex flex-col items-center gap-3'>
+            <div className={`flex aspect-square w-full items-center justify-center rounded-lg bg-muted/20 md:w-48 ${isKnockedOut ? 'opacity-50 grayscale' : ''}`}>
+              {character.type ? (
+                <Image
+                  src={`/characters/${character.type}/rotations/south.png`}
+                  alt={character.type}
+                  width={192}
+                  height={192}
+                  style={{ imageRendering: 'pixelated' }}
+                />
+              ) : (
+                <User className='size-20' />
+              )}
+            </div>
+            {isKnockedOut && (
+              <Button variant='destructive' onClick={handleRevive} disabled={reviving}>
+                {reviving ? 'Reviving...' : 'Revive'}
+              </Button>
             )}
           </div>
 

--- a/app/app/dashboard/index.tsx
+++ b/app/app/dashboard/index.tsx
@@ -1,12 +1,28 @@
+'use client'
+
 import { LiveOnlineMap } from '@/components/live-online-map'
 import { WeatherQuestCard } from '@/components/weather-quest-card'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 
 export default function Dashboard() {
+  const isLargeScreen = useMediaQuery('(min-width: 1024px)')
+
+  if (isLargeScreen) {
+    return (
+      <div className='flex gap-6'>
+        <div className='flex-1 min-w-0'><LiveOnlineMap /></div>
+        <div className='flex-1 min-w-0 flex flex-col gap-4'>
+          <WeatherQuestCard />
+          {/* heatmap card goes here */}
+        </div>
+      </div>
+    )
+  }
 
   return (
-  <div className='flex flex-1 flex-col gap-4'>
-    <WeatherQuestCard />
-    <LiveOnlineMap />
-  </div>
+    <div className='flex flex-1 flex-col gap-4'>
+      <WeatherQuestCard />
+      <LiveOnlineMap />
+    </div>
   )
 }

--- a/app/app/habits/index.tsx
+++ b/app/app/habits/index.tsx
@@ -26,11 +26,15 @@ function weightLabel(w: number) {
 export default function HabitsPage({
   activeTab,
   setActiveTab,
+  isLargeScreen,
 }: {
   activeTab: 'habits' | 'todos'
   setActiveTab: (tab: 'habits' | 'todos') => void
+  isLargeScreen: boolean
 }) {
   const { user } = useAuth()
+  const [habitDialogOpen, setHabitDialogOpen] = useState(false)
+  const [todoDialogOpen, setTodoDialogOpen] = useState(false)
 
   if (!user) return null
 
@@ -50,28 +54,61 @@ export default function HabitsPage({
         </Tooltip>
       </div>
 
-      <div className='flex gap-2'>
-        <Button variant={activeTab === 'habits' ? 'default' : 'outline'} onClick={() => setActiveTab('habits')}>
-          Habits
-        </Button>
-        <Button variant={activeTab === 'todos' ? 'default' : 'outline'} onClick={() => setActiveTab('todos')}>
-          To-Dos
-        </Button>
-      </div>
+      {!isLargeScreen && (
+        <div className='flex gap-2'>
+          <Button variant={activeTab === 'habits' ? 'default' : 'outline'} onClick={() => setActiveTab('habits')}>
+            Habits
+          </Button>
+          <Button variant={activeTab === 'todos' ? 'default' : 'outline'} onClick={() => setActiveTab('todos')}>
+            To-Dos
+          </Button>
+        </div>
+      )}
 
-      {activeTab === 'habits' && <HabitsSection userId={user.id} />}
-      {activeTab === 'todos' && <TodosSection userId={user.id} />}
+      {isLargeScreen ? (
+        <div className='flex gap-6'>
+          <div className='flex-1 min-w-0 flex flex-col gap-3'>
+            <div className='flex items-center justify-between'>
+              <h3 className='text-lg font-semibold'>Habits</h3>
+              <Button className='w-fit' onClick={() => setHabitDialogOpen(true)}><Plus /> Add Habit</Button>
+            </div>
+            <div className='border rounded-lg p-4'>
+              <HabitsSection userId={user.id} dialogOpen={habitDialogOpen} setDialogOpen={setHabitDialogOpen} />
+            </div>
+          </div>
+          <div className='flex-1 min-w-0 flex flex-col gap-3'>
+            <div className='flex items-center justify-between'>
+              <h3 className='text-lg font-semibold'>To-Dos</h3>
+              <Button className='w-fit' onClick={() => setTodoDialogOpen(true)}><Plus /> Add To-Do</Button>
+            </div>
+            <div className='border rounded-lg p-4'>
+              <TodosSection userId={user.id} dialogOpen={todoDialogOpen} setDialogOpen={setTodoDialogOpen} />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          {activeTab === 'habits' && <HabitsSection userId={user.id} />}
+          {activeTab === 'todos' && <TodosSection userId={user.id} />}
+        </>
+      )}
     </main>
   )
 }
 
 // ============================== habits ==============================
 
-function HabitsSection({ userId }: { userId: string | number }) {
+function HabitsSection({ userId, dialogOpen: controlledOpen, setDialogOpen: setControlledOpen }: {
+  userId: string | number
+  dialogOpen?: boolean
+  setDialogOpen?: (v: boolean) => void
+}) {
   const api = useApi()
   const [habits, setHabits] = useState<Habit[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
+  const [internalOpen, setInternalOpen] = useState(false)
+  const dialogOpen = controlledOpen ?? internalOpen
+  const setDialogOpen = setControlledOpen ?? setInternalOpen
 
   const [newHabit, setNewHabit] = useState<NewHabit>({
     title: '',
@@ -135,11 +172,13 @@ function HabitsSection({ userId }: { userId: string | number }) {
   return (
     <div className='flex flex-col gap-4'>
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogTrigger asChild>
-          <Button className='w-fit'>
-            <Plus /> Add Habit
-          </Button>
-        </DialogTrigger>
+        {!setControlledOpen && (
+          <DialogTrigger asChild>
+            <Button className='w-fit'>
+              <Plus /> Add Habit
+            </Button>
+          </DialogTrigger>
+        )}
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create New Habit</DialogTitle>
@@ -150,7 +189,7 @@ function HabitsSection({ userId }: { userId: string | number }) {
 
       {/* list */}
       {habits.length === 0 ? (
-        <EmptyState message='No habits yet. Add one to start earning XP!' />
+        <EmptyState message='No habits yet. Add one to start earning XP and building your streak!' />
       ) : (
         <div className='flex flex-col gap-3'>
           {habits.some((h) => h.penaltyApplied) && (
@@ -175,11 +214,17 @@ function HabitsSection({ userId }: { userId: string | number }) {
 
 // ============================== todos ==============================
 
-function TodosSection({ userId }: { userId: string | number }) {
+function TodosSection({ userId, dialogOpen: controlledOpen, setDialogOpen: setControlledOpen }: {
+  userId: string | number
+  dialogOpen?: boolean
+  setDialogOpen?: (v: boolean) => void
+}) {
   const api = useApi()
   const [todos, setTodos] = useState<Todo[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
+  const [internalOpen, setInternalOpen] = useState(false)
+  const dialogOpen = controlledOpen ?? internalOpen
+  const setDialogOpen = setControlledOpen ?? setInternalOpen
 
   const [newTodo, setNewTodo] = useState<NewTodo>({
     title: '',
@@ -246,11 +291,13 @@ function TodosSection({ userId }: { userId: string | number }) {
   return (
     <div className='flex flex-col gap-4'>
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogTrigger asChild>
-          <Button className='w-fit'>
-            <Plus /> Add To-Do
-          </Button>
-        </DialogTrigger>
+        {!setControlledOpen && (
+          <DialogTrigger asChild>
+            <Button className='w-fit'>
+              <Plus /> Add To-Do
+            </Button>
+          </DialogTrigger>
+        )}
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create New To-Do</DialogTitle>
@@ -260,7 +307,7 @@ function TodosSection({ userId }: { userId: string | number }) {
       </Dialog>
 
       {todos.length === 0 ? (
-        <EmptyState message='No to-dos yet. Add one to start!' />
+        <EmptyState message='No to-dos yet. Add one to start earning XP!' />
       ) : (
         <div className='flex flex-col gap-3'>
           {todos.map((todo) => (

--- a/app/app/page.client.tsx
+++ b/app/app/page.client.tsx
@@ -4,6 +4,7 @@ import { AppSidebar } from '@/components/app-sidebar'
 import { Separator } from '@/components/ui/separator'
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { WeatherIcon } from '@/components/weather-icon'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import BossRaidPage from './boss-raid'
@@ -15,23 +16,6 @@ import LeaderboardPage from './leaderboard'
 import AccountPage from './account'
 import { Onboarding } from '@/components/ui/onboarding'
 
-interface PageTitle {
-  title: string
-  subtitle?: string
-}
-
-const getPageTitle = (page: string, tab: 'habits' | 'todos' = 'habits'): PageTitle => {
-  const titles: Record<string, PageTitle> = {
-    dashboard: { title: 'Dashboard' },
-    habits: { title: tab === 'todos' ? 'To-Dos' : 'Habits'},
-    character: { title: 'Character' },
-    groups: { title: 'Groups' },
-    'boss-raids': { title: 'Boss Raids' },
-    leaderboard: { title: 'Leaderboard' },
-    account: { title: 'Account' },
-  }
-  return titles[page] || { title: 'Dashboard' }
-}
 
 export default function ClientApplicationPage({ weatherCode }: { weatherCode: number | null }) {
   const router = useRouter()
@@ -39,10 +23,11 @@ export default function ClientApplicationPage({ weatherCode }: { weatherCode: nu
   const searchParams = useSearchParams()
   const [currentPage, setCurrentPage] = useState(searchParams.get('page') ?? 'dashboard')
   const [activeTab, setActiveTab] = useState<'habits' | 'todos'>('habits')
+  const isLargeScreen = useMediaQuery('(min-width: 1024px)')
 
   const pageTitles: Record<string, string> = {
     dashboard: 'Dashboard',
-    habits: activeTab === 'todos' ? 'To-Dos' : 'Habits',
+    habits: isLargeScreen ? 'Tasks' : activeTab === 'todos' ? 'To-Dos' : 'Habits',
     character: 'Character',
     groups: 'Groups',
     'boss-raids': 'Boss Raids',
@@ -74,17 +59,14 @@ export default function ClientApplicationPage({ weatherCode }: { weatherCode: nu
         <div className='flex w-full flex-col p-12 pt-0'>
           <div className='flex items-center justify-between gap-4 mb-6'>
             <div className='flex flex-col'>
-              <h2>{getPageTitle(currentPage, activeTab).title}</h2>
-              {getPageTitle(currentPage, activeTab).subtitle && (
-                <p className='text-sm text-muted-foreground'>{getPageTitle(currentPage, activeTab).subtitle}</p>
-              )}
+              <h2>{pageTitle}</h2>
             </div>
             <div className='shrink-0'>{weatherCode != null && <WeatherIcon weatherCode={weatherCode} />}</div>
           </div>
           <div className='flex-1'>
             {currentPage === 'dashboard' && <Dashboard />}
 
-            {currentPage === 'habits' && <HabitsPage activeTab={activeTab} setActiveTab={setActiveTab} />}
+            {currentPage === 'habits' && <HabitsPage activeTab={activeTab} setActiveTab={setActiveTab} isLargeScreen={isLargeScreen} />}
 
             {currentPage === 'character' && <CharacterPage />}
 

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -24,9 +24,10 @@ import { Input } from "@/components/ui/input"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/hooks/useAuth"
+import { toast } from "sonner"
 
 const loginSchema = z.object({
-  email: z.string().email("Please enter a valid email address."),
+  email: z.email("Please enter a valid email address."),
   password: z.string().min(1, "Password is required."),
 })
 
@@ -36,10 +37,10 @@ export function LoginForm({
 }: React.ComponentProps<"div">) {
   const router = useRouter()
   const { login } = useAuth()
-  const [formError, setFormError] = React.useState<string | null>(null)
 
   const form = useForm<z.infer<typeof loginSchema>>({
     resolver: zodResolver(loginSchema),
+    mode: "onBlur",
     defaultValues: {
       email: process.env.NEXT_PUBLIC_DEFAULT_EMAIL || "",
       password: process.env.NEXT_PUBLIC_DEFAULT_PASSWORD || "",
@@ -47,13 +48,11 @@ export function LoginForm({
   })
 
   async function onSubmit(data: z.infer<typeof loginSchema>) {
-    setFormError(null)
-
     try {
       await login(data)
       router.replace("/app")
     } catch (error) {
-      setFormError(error instanceof Error ? error.message : "Login failed")
+      toast.error(error instanceof Error ? error.message : "Login failed")
     }
   }
 
@@ -69,21 +68,20 @@ export function LoginForm({
         <CardContent>
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <FieldGroup>
-              <Field>
+              <Field data-invalid={!!form.formState.errors.email}>
                 <FieldLabel htmlFor="email">Email</FieldLabel>
                 <Input
                   {...form.register("email")}
                   id="email"
                   type="email"
                   placeholder="m@example.com"
-                  aria-invalid={form.formState.errors.email ? true : false}
-                  required
+                  aria-invalid={!!form.formState.errors.email}
                 />
                 {form.formState.errors.email && (
                   <FieldError errors={[form.formState.errors.email]} />
                 )}
               </Field>
-              <Field>
+              <Field data-invalid={!!form.formState.errors.password}>
                 <div className="flex items-center">
                   <FieldLabel htmlFor="password">Password</FieldLabel>
                   <a
@@ -97,15 +95,13 @@ export function LoginForm({
                   {...form.register("password")}
                   id="password"
                   type="password"
-                  aria-invalid={form.formState.errors.password ? true : false}
-                  required
+                  aria-invalid={!!form.formState.errors.password}
                 />
                 {form.formState.errors.password && (
                   <FieldError errors={[form.formState.errors.password]} />
                 )}
               </Field>
               <Field>
-                {formError && <FieldError>{formError}</FieldError>}
                 <Button type="submit" disabled={form.formState.isSubmitting}>
                   {form.formState.isSubmitting ? "Logging in..." : "Login"}
                 </Button>

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -37,7 +37,7 @@ const CHARACTER_TYPES = [
 const formSchema = z
   .object({
     username: z.string().min(2, 'Username must be at least 2 characters.'),
-    email: z.string().email('Please enter a valid email address.'),
+    email: z.email('Please enter a valid email address.'),
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters.')
@@ -53,12 +53,10 @@ const formSchema = z
 export function SignupForm({ className, ...props }: React.ComponentProps<'div'>) {
   const router = useRouter()
   const { register: registerUser } = useAuth()
-  const [formError, setFormError] = React.useState<string | null>(null)
-
-
   //set up zod form
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    mode: "onBlur",
     defaultValues: {
       username: process.env.NEXT_PUBLIC_DEFAULT_USERNAME || '',
       email: process.env.NEXT_PUBLIC_DEFAULT_EMAIL || '',
@@ -74,7 +72,7 @@ export function SignupForm({ className, ...props }: React.ComponentProps<'div'>)
   async function onSubmit(data: z.infer<typeof formSchema>) {
     try {
       //send data to backend -> POST /users
-      const user = await registerUser({
+      await registerUser({
         username: data.username,
         email: data.email,
         password: data.password,
@@ -85,9 +83,8 @@ export function SignupForm({ className, ...props }: React.ComponentProps<'div'>)
       router.replace('/app')
 
       //check for backedn errors
-    } catch (error: any) {
-      //extract error message from backend response
-      const errorMessage = error.response?.data?.message || error.message || "";
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : "";
 
       //use form.setError to check for duplicates
       if (errorMessage.toLowerCase().includes("username")) {
@@ -106,7 +103,7 @@ export function SignupForm({ className, ...props }: React.ComponentProps<'div'>)
 
       //catch all other errors and display error message
       if (!errorMessage.toLowerCase().includes("username") && !errorMessage.toLowerCase().includes("email")) {
-        setFormError(errorMessage || 'Registration failed')
+        toast.error(errorMessage || 'Registration failed')
       }
     }
   }
@@ -217,7 +214,6 @@ export function SignupForm({ className, ...props }: React.ComponentProps<'div'>)
               />
 
               <Field>
-                {formError && <FieldError>{formError}</FieldError>}
                 <Button type='submit' disabled={form.formState.isSubmitting}>
                   {form.formState.isSubmitting ? 'Creating account...' : 'Sign up'}
                 </Button>

--- a/components/todo-card.tsx
+++ b/components/todo-card.tsx
@@ -72,6 +72,10 @@ export function TodoCard({ todo, onComplete, onDelete }: TodoCardProps) {
 
             <p className='text-xs text-muted-foreground'>Completes for {todo.weight * 10} XP</p>
 
+            {todo.dueAt && !todo.completed && (
+              <p className='text-xs text-muted-foreground'>Due: {new Date(todo.dueAt).toLocaleDateString('en-GB')}</p>
+            )}
+
             <div className='flex items-center gap-2'>
               <Button size='icon-lg' onClick={onComplete} disabled={todo.completed}>
                 <Check />

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const mq = window.matchMedia(query)
+    setMatches(mq.matches)
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [query])
+
+  return matches
+}

--- a/providers/auth-provider.tsx
+++ b/providers/auth-provider.tsx
@@ -66,10 +66,11 @@ async function parseError(res: Response, fallback: string): Promise<never> {
   try {
     const payload = await res.json()
     const reason = readReason(payload)
-    throw new Error(reason ?? fallback)
-  } catch {
-    throw new Error(fallback)
+    if (reason) throw new Error(reason)
+  } catch (err) {
+    if (err instanceof Error) throw err
   }
+  throw new Error(fallback)
 }
 
 function buildAuthUrl(path: string): string {


### PR DESCRIPTION
- added skip button to boss raid task card and in backend new endpoint POST /raids/{id}/tasks/{id}/skip -> closes #128 
- when character dies, character page now also shows character in grey + revive button when health <= 0, like sidebar widget
- character page subscribes to WebSocket character updates so stats and dead state sync without page navigation otherwise character being displayed as revived in widget but not on character page -> closes #141  
- responsive layout for dashboard and habits/todos page: on large screens (≥1024px), components render side-by-side using "useMediaQuery" -> closes #136 
- login and signup forms: replaced inline form error state with toast.error, added onBlur validation mode, fixed aria-invalid attributes
- signup form: fixed error handling to use instanceof Error instead of any with .response?.data
- auth provider: fixed parseError swallowing thrown errors by re-throwing Error instances before falling back
- todo card now displays due date when set and not yet completed so all cards are more or less the same size